### PR TITLE
export Ember.Handlebars for 3rd party compile-to-handlebars lang support

### DIFF
--- a/lib/ember-dev/rakep/filters.rb
+++ b/lib/ember-dev/rakep/filters.rb
@@ -123,6 +123,7 @@ class EmberStub < Rake::Pipeline::Filter
       file = File.read(input.fullpath)
       out = "(function() {\nvar Ember = { assert: function() {} };\n"
       out << file
+      out << "\nexports.emberHandlebars = Ember.Handlebars;"
       out << "\nexports.precompile = Ember.Handlebars.precompile;"
       out << "\n})()"
       output.write out


### PR DESCRIPTION
In other words, I really need this for https://github.com/machty/emblem.js so that I can access the handlebars AST.
