### PR TITLE
Fix for developing against Ember RC 1

### DIFF
--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -67,7 +67,7 @@
   </script>
 
   <script type="text/javascript">
-    var handlebarsVersion = QUnit.urlParams.handlebars || "1.0.rc.2";
+    var handlebarsVersion = QUnit.urlParams.handlebars || "1.0.0.rc.3";
 
     // Fallback to default Handlebars
     if (handlebarsVersion !== 'none') {


### PR DESCRIPTION
The version scheme for the required Handlebars changed from X.X.rc.X pre
RC 1 in Ember to X.X.X.rc.X post RC 1. This fix will fix the version
scheme so handlebars will be properly loaded.
