### PR TITLE
Update default handlebars version to 1.0.0-rc.3

### DIFF
--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -67,7 +67,7 @@
   </script>
 
   <script type="text/javascript">
-    var handlebarsVersion = QUnit.urlParams.handlebars || "1.0.rc.2";
+    var handlebarsVersion = QUnit.urlParams.handlebars || "1.0.0-rc.3";
 
     // Fallback to default Handlebars
     if (handlebarsVersion !== 'none') {


### PR DESCRIPTION
This updates the default handlebars.js version to match the minimum requirement for Ember RC1.
