### PR TITLE
Avoid 'already initialized constant' warning

### DIFF
--- a/lib/ember-dev/tasks.rb
+++ b/lib/ember-dev/tasks.rb
@@ -1,3 +1,5 @@
 require 'ember-dev'
 
+EMBER_VERSION = File.read("VERSION").strip
+
 Dir[File.expand_path("../../tasks/**/*.rake", __FILE__)].each{|f| load f }

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -1,5 +1,3 @@
-EMBER_VERSION = File.read("VERSION").strip
-
 namespace :ember do
   namespace :release do
     def pretend?


### PR DESCRIPTION
Related with emberjs/ember.js#2109
