### PR TITLE
Use handlebars-source gem instead of vendored handlebars.js

### DIFF
--- a/ember-dev.gemspec
+++ b/ember-dev.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "kicker"
   gem.add_dependency "grit"
   gem.add_dependency "execjs"
+  gem.add_dependency "handlebars-source"
 end
 

--- a/lib/ember-dev/server.rb
+++ b/lib/ember-dev/server.rb
@@ -1,9 +1,24 @@
 require 'rake-pipeline'
 require 'rake-pipeline/middleware'
 require 'erb'
+require 'handlebars/source'
 
 module EmberDev
   class Server
+    class HandlebarsJS
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        if env['PATH_INFO'] == '/handlebars.js'
+          [200, {'Content-Type' => 'text/javascript'}, [File.read(Handlebars::Source.bundled_path)]]
+        else
+          @app.call(env)
+        end
+      end
+    end
+
     class NoCache
       def initialize(app)
         @app = app
@@ -38,6 +53,7 @@ module EmberDev
       tests_root = File.expand_path("../../../support/tests", __FILE__)
 
       @app = Rack::Builder.app do
+        use HandlebarsJS
         use NoCache
         use Rake::Pipeline::Middleware, project
         use ErbIndex, tests_root

--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -67,18 +67,18 @@
   </script>
 
   <script type="text/javascript">
-    var handlebarsVersion = QUnit.urlParams.handlebars || "1.0.0-rc.3";
 
-    // Fallback to default Handlebars
+    var handlebarsVersion = QUnit.urlParams.handlebars;
+
     if (handlebarsVersion !== 'none') {
-      loadScript('/lib/handlebars-'+handlebarsVersion+'.js');
+      loadScript('/handlebars.js');
     }
     // Close the script tag to make sure document.write happens
   </script>
 
   <script type="text/javascript">
     if (handlebarsVersion !== 'none' && !window.Handlebars) {
-      if (window.console && console.warn) { console.warn("Unable to load Handlebars "+handlebarsVersion+"."); }
+      if (window.console && console.warn) { console.warn("Unable to load Handlebars."); }
     }
     // Close the script tag to make sure document.write happens
   </script>


### PR DESCRIPTION
Switch to using [handlebars-source](https://rubygems.org/gems/handlebars-source) instead of vendored handlebars .js files. This has been tested with ember master; all tests pass.
