### PR TITLE
ember-template-compiler exports EmberHandlebars

### DIFF
--- a/lib/ember-dev/rakep/filters.rb
+++ b/lib/ember-dev/rakep/filters.rb
@@ -135,6 +135,7 @@ class EmberStub < Rake::Pipeline::Filter
 
       out << file
       out << "\nexports.precompile = Ember.Handlebars.precompile;"
+      out << "\nexports.EmberHandlebars = Ember.Handlebars;"
       out << "\n})();"
       output.write out
     end


### PR DESCRIPTION
The Emberized variant of Handlebars should be considered one of the exports/outputs of the ember-template-compiler for those who need it in addition to the exported `precompile` function, e.g. Emblem and anyone else who needs access to the modified EmberHandlebars object. 

This was original put forth as https://github.com/emberjs/ember-dev/pull/1 and closed in favor of splitting out Handlebars, which we did already, but I forgot there are properties Emblem needs to read from the EmberHandlebars object, hence this change. 
