### PR TITLE
added dependency on ember-source for ember-data et al testing

### DIFF
--- a/ember-dev.gemspec
+++ b/ember-dev.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "grit"
   gem.add_dependency "execjs"
   gem.add_dependency "handlebars-source"
+  gem.add_dependency "ember-source"
 end
 

--- a/lib/ember-dev/server.rb
+++ b/lib/ember-dev/server.rb
@@ -2,6 +2,7 @@ require 'rake-pipeline'
 require 'rake-pipeline/middleware'
 require 'erb'
 require 'handlebars/source'
+require 'ember/source'
 
 module EmberDev
   class Server
@@ -13,6 +14,20 @@ module EmberDev
       def call(env)
         if env['PATH_INFO'] == '/handlebars.js'
           [200, {'Content-Type' => 'text/javascript'}, [File.read(Handlebars::Source.bundled_path)]]
+        else
+          @app.call(env)
+        end
+      end
+    end
+
+    class EmberJS
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        if env['PATH_INFO'] == '/ember.js'
+          [200, {'Content-Type' => 'text/javascript'}, [File.read(::Ember::Source.bundled_path_for("ember.js"))]]
         else
           @app.call(env)
         end
@@ -54,6 +69,7 @@ module EmberDev
 
       @app = Rack::Builder.app do
         use HandlebarsJS
+        use EmberJS
         use NoCache
         use Rake::Pipeline::Middleware, project
         use ErbIndex, tests_root

--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -90,7 +90,10 @@
   <% end %>
 
   <% unless EmberDev.config.testing_ember %>
-    <script type="text/javascript" src="modules/ember.js"></script>
+    <script type="text/javascript">
+      loadScript('/ember.js');
+      // Close the script tag to make sure document.write happens
+    </script>
   <% end %>
 
   <script>


### PR DESCRIPTION
Even though ember.js build/test process won't use this (because testing_ember: true), ember-data and all other packages that shouldn't have to keep their own vendored ember.js will use this. 

This has been tested building/testing ember.js and ember-data
