### PR TITLE
add utilities for rake tasks to plug into for automatic s3 builds

### DIFF
--- a/ember-dev.gemspec
+++ b/ember-dev.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "execjs"
   gem.add_dependency "handlebars-source"
   gem.add_dependency "ember-source"
+  gem.add_dependency "aws-sdk"
 end
 

--- a/lib/ember-dev.rb
+++ b/lib/ember-dev.rb
@@ -2,6 +2,7 @@ module EmberDev
   autoload :Config,  'ember-dev/config'
   autoload :Server,  'ember-dev/server'
   autoload :Version, 'ember-dev/version'
+  autoload :Publish ,'ember-dev/publish'
 
   def self.config
     @@config ||= Config.from_file('ember-dev.yml')

--- a/lib/ember-dev/publish.rb
+++ b/lib/ember-dev/publish.rb
@@ -1,0 +1,35 @@
+module EmberDev
+  class Publish
+    require 'aws-sdk'
+
+    def self.to_s3(opts={})
+      access_key_id = opts.fetch :access_key_id
+      secret_access_key = opts.fetch :secret_access_key
+      bucket_name = opts.fetch :bucket_name
+      files = opts.fetch :files
+      rev=`git rev-list HEAD -n 1`.to_s.strip
+      master_rev = `git rev-list origin/master -n 1`.to_s.strip
+      return unless rev == master_rev
+      return unless access_key_id && secret_access_key && bucket_name
+      s3 = AWS::S3.new(
+        :access_key_id => access_key_id,
+        :secret_access_key => secret_access_key)
+      bucket = s3.buckets[bucket_name]
+      files.each do |file|
+        filename = file.split('.js').first.split('/').last
+        minified_files = []
+        unminified_files = []
+        unminified_files << bucket.objects["#{filename}-latest.js"]
+        unminified_files << bucket.objects["#{filename}-#{rev}.js"]
+        minified_files << bucket.objects["#{filename}-latest.min.js"]
+        minified_files << bucket.objects["#{filename}-#{rev}.min.js"]
+        unminified_files.each { |obj| obj.write Pathname.new file }
+        minified_files.each { |obj|
+          obj.write Pathname.new file.sub("/#{filename}.js$", filename + '.min.js')
+        }
+      end
+    end
+
+  end
+end
+


### PR DESCRIPTION
this just lets us have less code duplication between data and ember.js for the "publishing passing builds automatically to s3" stuff. I'll be adding a pull request for both those projects shortly.
