### PR TITLE
Resolve rubygems dependency issue with ember-source

### DIFF
--- a/ember-dev.gemspec
+++ b/ember-dev.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "kicker"
   gem.add_dependency "grit"
   gem.add_dependency "execjs"
-  gem.add_dependency "handlebars-source"
+  gem.add_dependency "handlebars-source", [">= 1.0.0.rc3", "< 1.0.0.rc4"]
   gem.add_dependency "ember-source"
   gem.add_dependency "aws-sdk"
 end


### PR DESCRIPTION
Because ember-source has a complex handlebars-source dependency the dependency resolver on rubygems.org is having a hardtime reconciling this with the handlebars-source dependency version in ember-dev. It is true they should both be OK but in reality they are causing a conflict.

This will set the version of handlebars-source to match the dependency version in ember-source to resolve this issue.
