### PR TITLE
Add homepage to avoid warning on `gem build`

### DIFF
--- a/ember-dev.gemspec
+++ b/ember-dev.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["peter.wagenet@gmail.com"]
   gem.description   = "Ember Package Development Tooling"
   gem.summary       = "Tooling for developing Ember packages."
-  gem.homepage      = ""
+  gem.homepage      = "https://github.com/emberjs/ember-dev"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
On `gem build ember-dev.gemspec` the following warning is shown:

```
WARNING:  no homepage specified
```
