### PR TITLE
add support for loading ember-data

### DIFF
--- a/lib/ember-dev/config.rb
+++ b/lib/ember-dev/config.rb
@@ -11,6 +11,7 @@ module EmberDev
     attr_accessor :testing_suites
     attr_accessor :testing_packages
     attr_accessor :testing_additional_requires
+    attr_accessor :testing_needs_ember_data
     attr_accessor :testing_ember
 
     def initialize(hash)

--- a/lib/ember-dev/server.rb
+++ b/lib/ember-dev/server.rb
@@ -31,6 +31,20 @@ module EmberDev
         end
       end
     end
+    
+    class EmberData
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        if env['PATH_INFO'] == '/ember-data.js'
+          [200, {'Content-Type' => 'text/javascript'}, [File.read(::Ember::Data::Source.bundled_path_for("ember-data.js"))]]
+        else
+          @app.call(env)
+        end
+      end
+    end
 
     class NoCache
       def initialize(app)
@@ -73,6 +87,7 @@ module EmberDev
         # Include these after RakeP so we can serve from RakeP if available
         use HandlebarsJS
         use EmberJS
+        use EmberData
 
         use ErbIndex, tests_root
         run Rack::Directory.new(tests_root)

--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -96,6 +96,13 @@
     </script>
   <% end %>
 
+  <% if EmberDev.config.testing_needs_ember_data %>
+    <script type="text/javascript">
+      loadScript('/ember-data.js');
+      // Close the script tag to make sure document.write happens
+    </script>
+  <% end %>
+
   <script>
     // Load ember distribution from query vars
     var distMatch = location.search.match(/dist=([^&]+)/),


### PR DESCRIPTION
This allows libraries (such as 3rd party adapters) to use ember-dev and not have to embed ember-data
