### PR TITLE
Use config name in test page header

### DIFF
--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -34,7 +34,7 @@
   <script type="text/javascript" src="qunit_configuration.js"></script>
 </head>
 <body>
-  <h1 id="qunit-header">Ember.js Test Suite</h1>
+  <h1 id="qunit-header"><%= EmberDev.config.name %> Test Suite</h1>
   <h2 id="qunit-banner"></h2>
   <div id="qunit-testrunner-toolbar"></div>
   <h2 id="qunit-userAgent"></h2>


### PR DESCRIPTION
instead of "Ember.js" for all projects. Just a little update as I'm using this library for EmberLeaflet even though it's unsupported. Working great!
