### PR TITLE
Rethink stable targets.

### DIFF
--- a/lib/ember-dev/asset.rb
+++ b/lib/ember-dev/asset.rb
@@ -32,14 +32,23 @@ module EmberDev
       end
 
       def targets_for(extension)
-        latest_root   = "#{basename}-latest#{extension}"
-        latest_path   = "latest/#{basename}#{extension}"
-        daily_path    = "daily/#{Date.today.strftime('%Y%m%d')}/#{basename}#{extension}"
-        revision_path = "shas/#{current_revision}/#{basename}#{extension}"
-        tagged_path   = has_tag ? "tags/#{current_tag}/#{basename}#{extension}" : nil
-        stable_path   = stable ? "stable/#{basename}#{extension}" : nil
+        targets = []
+        prefix  = ''
 
-        [latest_root, latest_path, daily_path, revision_path, tagged_path, stable_path].compact
+        if stable
+          prefix  = 'stable/'
+          targets << "#{prefix}#{basename}#{extension}"
+        else
+          targets << "#{basename}-latest#{extension}"
+          targets << "latest/#{basename}#{extension}"
+        end
+
+        targets << "#{prefix}daily/#{Date.today.strftime('%Y%m%d')}/#{basename}#{extension}"
+        targets << "#{prefix}shas/#{current_revision}/#{basename}#{extension}"
+
+        targets << "tags/#{current_tag}/#{basename}#{extension}" if has_tag
+
+        targets.compact
       end
 
       def unminified_targets

--- a/lib/ember-dev/publish.rb
+++ b/lib/ember-dev/publish.rb
@@ -43,7 +43,7 @@ module EmberDev
       }
 
       files.each do |file|
-        asset_file = Asset.new(file, opts.merge(:stable => building_stable)
+        asset_file = Asset.new(file, opts.merge(:stable => building_stable))
 
         asset_file.files_for_publishing.each do |source_file, target_files|
           target_files.each do |target_file|

--- a/tests/asset_spec.rb
+++ b/tests/asset_spec.rb
@@ -35,9 +35,10 @@ describe EmberDev::Publish::Asset do
     end
 
     it "includes stable path if a stable => true" do
+      stable_targets = %W{stable/ember.js stable/daily/#{todays_date}/ember.js stable/shas/BLAHBLAH/ember.js tags/v999/ember.js}
       asset_file = described_class.new('some_dir/ember.js', revision: 'BLAHBLAH', tag: 'v999', stable: true)
 
-      assert_equal base_targets + %w{tags/v999/ember.js stable/ember.js}, asset_file.targets_for('.js')
+      assert_equal stable_targets, asset_file.targets_for('.js')
     end
   end
 


### PR DESCRIPTION
Without this change a push to `stable` would overwrite `latest/ember.js`, `ember-latest.js`, and `daily/YYYYMMDD/ember.js`.

This PR adds a whole new layer of output for the `stable` branch.

Full output for the following scenarios:

Stable commit:

``` ruby
file = EmberDev::Publish::Asset.new('ember.js', :stable => true)
file.targets_for('.js')

=> ["stable/ember.js",
    "stable/daily/20130826/ember.js",
    "stable/shas/3385bffee116a97c555b9672b64297fe283cfa5b/ember.js"]
```

Master Commit:

``` ruby
file = EmberDev::Publish::Asset.new('ember.js')
file.targets_for('.js')

=> ["ember-latest.js",
    "latest/ember.js",
    "daily/20130826/ember.js",
    "shas/3385bffee116a97c555b9672b64297fe283cfa5b/ember.js"]
```

For tagged commits the following will also be output:

```
tags/v999/ember.js
```
