### PR TITLE
Update asset targets for canary/beta/release.

### DIFF
--- a/lib/ember-dev/asset.rb
+++ b/lib/ember-dev/asset.rb
@@ -4,7 +4,7 @@ require_relative 'publish'
 module EmberDev
   module Publish
     class Asset
-      attr_accessor :file, :current_revision, :current_tag, :stable
+      attr_accessor :file, :current_revision, :current_tag, :build_type
 
       def initialize(filename, options = nil)
         options              ||= {}
@@ -12,7 +12,7 @@ module EmberDev
         self.file             = Pathname.new(filename)
         self.current_revision = options.fetch(:revision) { EmberDev::Publish.current_revision }
         self.current_tag      = options.fetch(:tag)      { EmberDev::Publish.current_tag }
-        self.stable           = options.fetch(:stable)   { false }
+        self.build_type       = options.fetch(:build_type)   { :canary }
       end
 
       def basename
@@ -27,22 +27,23 @@ module EmberDev
         current_tag.to_s != ''
       end
 
-      def stable
-        @stable
-      end
-
       def targets_for(extension)
         targets = []
         prefix  = ''
 
-        if stable
-          prefix  = 'stable/'
-          targets << "#{prefix}#{basename}#{extension}"
-        else
+        case build_type
+        when :canary
+          prefix  = 'canary/'
           targets << "#{basename}-latest#{extension}"
           targets << "latest/#{basename}#{extension}"
+        when :beta
+          prefix  = 'beta/'
+        when :release
+          prefix  = 'release/'
+          targets << "stable/#{basename}#{extension}"
         end
 
+        targets << "#{prefix}#{basename}#{extension}"
         targets << "#{prefix}daily/#{Date.today.strftime('%Y%m%d')}/#{basename}#{extension}"
         targets << "#{prefix}shas/#{current_revision}/#{basename}#{extension}"
 

--- a/tests/asset_spec.rb
+++ b/tests/asset_spec.rb
@@ -20,7 +20,12 @@ describe EmberDev::Publish::Asset do
   end
 
   describe "#targets_for" do
-    let(:base_targets) { %W{ember-latest.js latest/ember.js daily/#{todays_date}/ember.js shas/BLAHBLAH/ember.js} }
+    let(:base_targets) {
+      %W{ ember-latest.js
+          latest/ember.js
+          canary/ember.js
+          canary/daily/#{todays_date}/ember.js
+          canary/shas/BLAHBLAH/ember.js} }
 
     it "doesn't return the tagged_path if no tag is present" do
       asset_file = described_class.new('some_dir/ember.js', revision: 'BLAHBLAH', tag: '')
@@ -35,8 +40,13 @@ describe EmberDev::Publish::Asset do
     end
 
     it "includes stable path if a stable => true" do
-      stable_targets = %W{stable/ember.js stable/daily/#{todays_date}/ember.js stable/shas/BLAHBLAH/ember.js tags/v999/ember.js}
-      asset_file = described_class.new('some_dir/ember.js', revision: 'BLAHBLAH', tag: 'v999', stable: true)
+      stable_targets = %W{ stable/ember.js
+                           release/ember.js
+                           release/daily/#{todays_date}/ember.js
+                           release/shas/BLAHBLAH/ember.js
+                           tags/v999/ember.js}
+
+      asset_file = described_class.new('some_dir/ember.js', revision: 'BLAHBLAH', tag: 'v999', build_type: :release)
 
       assert_equal stable_targets, asset_file.targets_for('.js')
     end
@@ -44,20 +54,37 @@ describe EmberDev::Publish::Asset do
 
   it "returns a list of unminified_targets" do
     asset_file = described_class.new('some_dir/ember.js', revision: 'BLAHBLAH')
+    expected_targets = %W{ ember-latest.js
+                           latest/ember.js
+                           canary/ember.js
+                           canary/daily/#{todays_date}/ember.js
+                           canary/shas/BLAHBLAH/ember.js }
 
-    assert_equal %W{ember-latest.js latest/ember.js daily/#{todays_date}/ember.js shas/BLAHBLAH/ember.js}, asset_file.unminified_targets
+    assert_equal expected_targets, asset_file.unminified_targets
   end
 
   it "returns a list of minified_targets" do
+    expected_targets = %W{ ember-latest.min.js
+                           latest/ember.min.js
+                           canary/ember.min.js
+                           canary/daily/#{todays_date}/ember.min.js
+                           canary/shas/BLAHBLAH/ember.min.js}
+
     asset_file = described_class.new('ember.js', revision: 'BLAHBLAH')
 
-    assert_equal %W{ember-latest.min.js latest/ember.min.js daily/#{todays_date}/ember.min.js shas/BLAHBLAH/ember.min.js}, asset_file.minified_targets
+    assert_equal expected_targets, asset_file.minified_targets
   end
 
   it "returns a list of production_targets" do
+    expected_targets = %W{ember-latest.prod.js
+                          latest/ember.prod.js
+                          canary/ember.prod.js
+                          canary/daily/#{todays_date}/ember.prod.js
+                          canary/shas/BLAHBLAH/ember.prod.js}
+
     asset_file = described_class.new('ember.js', revision: 'BLAHBLAH')
 
-    assert_equal %W{ember-latest.prod.js latest/ember.prod.js daily/#{todays_date}/ember.prod.js shas/BLAHBLAH/ember.prod.js}, asset_file.production_targets
+    assert_equal expected_targets, asset_file.production_targets
   end
 
   it "knows the location of it's minified source" do


### PR DESCRIPTION
Assumptions for this PR:
- canary -> 'master' branch
- beta -> 'beta' branch
- release -> 'stable' | 'release' branch

Standard targets (non-tagged revisions) are:

``` ruby
EmberDev::Publish::Asset.new('ember.js', :build_type => :canary).targets_for('.js')
=> ["ember-latest.js",
    "latest/ember.js",
    "canary/ember.js",
    "canary/daily/20130901/ember.js",
    "canary/shas/600c5e6e0fd60903ad9cdc79839d338c7f994ec7/ember.js"]

EmberDev::Publish::Asset.new('ember.js', :build_type => :beta).targets_for('.js')
=> ["beta/ember.js",
    "beta/daily/20130901/ember.js",
    "beta/shas/600c5e6e0fd60903ad9cdc79839d338c7f994ec7/ember.js"]

EmberDev::Publish::Asset.new('ember.js', :build_type => :release).targets_for('.js')
=> ["stable/ember.js",
    "release/ember.js",
    "release/daily/20130901/ember.js",
    "release/shas/600c5e6e0fd60903ad9cdc79839d338c7f994ec7/ember.js"]
```

Tagged targets are:

``` ruby
EmberDev::Publish::Asset.new('ember.js', :build_type => :release, :tag => 'v999').targets_for('.js')
=> ["stable/ember.js",
    "release/ember.js",
    "release/daily/20130901/ember.js",
    "release/shas/600c5e6e0fd60903ad9cdc79839d338c7f994ec7/ember.js",
    "tags/v999/ember.js"]
```
