### PR TITLE
Generate a channel specific version file.

### DIFF
--- a/lib/ember-dev.rb
+++ b/lib/ember-dev.rb
@@ -8,7 +8,9 @@ module EmberDev
   autoload :TestSupport, 'ember-dev/test_support'
   autoload :TestRunner,  'ember-dev/test_runner'
   autoload :GitSupport,  'ember-dev/git_support'
-  autoload :DocumentationGenerator, 'ember-dev/documentation_generator'
+
+  autoload :DocumentationGenerator,       'ember-dev/documentation_generator'
+  autoload :ChannelReleasesFileGenerator, 'ember-dev/channel_releases_file_generator'
 
   def self.config
     @@config ||= Config.from_file('ember-dev.yml')

--- a/lib/ember-dev/channel_releases_file_generator.rb
+++ b/lib/ember-dev/channel_releases_file_generator.rb
@@ -1,0 +1,66 @@
+require 'json'
+require_relative 'publish'
+require_relative 'git_support'
+
+module EmberDev
+  class ChannelReleasesFileGenerator
+    attr_reader :git_support, :project_name
+    private :git_support
+
+    def initialize(options = nil)
+      options ||= {}
+
+      @git_support = options.fetch(:git_support) { GitSupport.new }
+      @project_name = options.fetch(:project_name) { EmberDev::Config.from_file('ember-dev.yml').name }
+    end
+
+    def dasherized_project_name(name = project_name)
+      name.gsub(/\W/, '-').downcase
+    end
+
+    def current_branch
+      git_support.current_branch
+    end
+
+    def current_tag
+      git_support.current_tag
+    end
+
+    def last_release(tag = current_tag)
+      tag =~ /v(.+)/; $1
+    end
+
+    def future_version(tag = current_tag)
+      tag =~ /v([0-9.]+)(?:-.+)?/; $1
+    end
+
+    def channel(branch = current_branch)
+      case branch
+      when 'stable','release' then 'release'
+      when 'beta'             then 'beta'
+      when 'master'           then 'canary'
+      end
+    end
+
+    def content
+      { 'projectName'   => project_name,
+        'projectFilter' => dasherized_project_name,
+        'lastRelease'   => last_release,
+        'futureVersion' => future_version,
+        'channel'       => channel,
+        'date'          => Date.today.to_s }
+    end
+
+    def to_json
+      content.to_json
+    end
+
+    def destination_path(channel = channel, dasherized_project_name = dasherized_project_name)
+      "/#{channel}/#{dasherized_project_name}-version.json"
+    end
+
+    def should_generate?
+      current_tag.to_s.strip.length > 0
+    end
+  end
+end

--- a/lib/ember-dev/publish.rb
+++ b/lib/ember-dev/publish.rb
@@ -1,7 +1,9 @@
 require 'aws-sdk'
 require 'zlib'
+
 require_relative 'asset'
 require_relative 'git_support'
+require_relative 'channel_releases_file_generator'
 
 module EmberDev
   module Publish
@@ -76,6 +78,13 @@ module EmberDev
         @s3_options = {
           :content_type     => 'text/javascript',
         }
+
+        generator = ChannelReleasesFileGenerator.new
+
+        if generator.should_generate?
+          obj = @bucket.objects[generator.destination_path]
+          obj.write(generator.to_json, {:content_type => 'application/json'})
+        end
       end
 
       files.each do |file|

--- a/spec/support/ember-dev.yml
+++ b/spec/support/ember-dev.yml
@@ -1,0 +1,2 @@
+---
+name: Ember Dev

--- a/spec/unit/channel_releases_file_generator_spec.rb
+++ b/spec/unit/channel_releases_file_generator_spec.rb
@@ -1,0 +1,111 @@
+require 'minitest/autorun'
+
+require_relative '../../lib/ember-dev'
+
+module EmberDev
+  describe ChannelReleasesFileGenerator do
+    let(:git_support_mock) { Minitest::Mock.new }
+    let(:generator) { ChannelReleasesFileGenerator.new(:git_support => git_support_mock, :project_name => 'Ember') }
+
+    it "uses the provided project name" do
+      generator = ChannelReleasesFileGenerator.new(:project_name => 'Ember Data')
+
+      assert_equal 'Ember Data', generator.project_name
+    end
+
+    it "uses infers the project name from ember-dev.yml in the working directory" do
+      Dir.chdir 'spec/support' do
+        generator = ChannelReleasesFileGenerator.new
+
+        assert_equal 'Ember Dev', generator.project_name
+      end
+    end
+
+    it "dasherizes the project name properly" do
+      assert_equal 'ember-dev', generator.dasherized_project_name('Ember Dev')
+      assert_equal 'ember-data', generator.dasherized_project_name('Ember Data')
+      assert_equal 'ember', generator.dasherized_project_name('Ember')
+    end
+
+    it "uses the provided GitSupport to determine the current branch" do
+      git_support_mock.expect :current_branch, 'blardy'
+
+      assert_equal 'blardy', generator.current_branch
+      git_support_mock.verify
+    end
+
+    it "uses the provided GitSupport to determine the current tag" do
+      git_support_mock.expect :current_tag, 'v9999.99'
+
+      assert_equal 'v9999.99', generator.current_tag
+      git_support_mock.verify
+    end
+
+    it "knows the correct future version" do
+      assert_equal '1.1.0', generator.future_version('v1.1.0-beta.1')
+      assert_equal '1.0.0', generator.future_version('v1.0.0')
+      assert_equal '1.0.1', generator.future_version('v1.0.1-rc.1')
+    end
+
+    it "knows the correct latest release" do
+      assert_equal '1.1.0-beta.1', generator.last_release('v1.1.0-beta.1')
+      assert_equal '1.0.0', generator.last_release('v1.0.0')
+      assert_equal '1.0.1-rc.1', generator.last_release('v1.0.1-rc.1')
+    end
+
+    it "knows the correct channel" do
+      assert_equal 'release', generator.channel('stable')
+      assert_equal 'beta', generator.channel('beta')
+      assert_equal 'canary', generator.channel('master')
+    end
+
+    describe "generates the correct content" do
+      let(:generator) {ChannelReleasesFileGenerator.new(:git_support => git_support_mock, :project_name => 'Ember Data') }
+      let(:expected_content_hash) do
+        { 'projectName' => 'Ember Data',
+          'projectFilter' => 'ember-data',
+          'lastRelease' => '1.1.0-beta.1',
+          'futureVersion' => '1.1.0',
+          'channel'     => 'beta',
+          'date'        => Date.today.to_s }
+      end
+
+      before do
+        git_support_mock.expect :current_branch, 'beta'
+        git_support_mock.expect :current_tag, 'v1.1.0-beta.1'
+        git_support_mock.expect :current_tag, 'v1.1.0-beta.1'
+      end
+
+      it "for tagged betas" do
+        assert_equal expected_content_hash, generator.content
+      end
+
+      it "produces valid JSON representing the content" do
+        output = generator.to_json
+
+        parsed_json = JSON.parse(output)
+
+        assert_equal expected_content_hash, parsed_json
+      end
+    end
+
+    it "knows where it should go in S3" do
+      assert_equal '/release/ember-version.json', generator.destination_path('release', 'ember')
+      assert_equal '/beta/ember-data-version.json', generator.destination_path('beta', 'ember-data')
+      assert_equal '/canary/ember-version.json', generator.destination_path('canary', 'ember')
+    end
+
+    it "should return true to update? when a tag exists" do
+      git_support_mock.expect :current_tag, 'v1.1.0-beta.1'
+
+      assert_equal true, generator.should_generate?
+    end
+
+    it "should return true to update? when a tag exists" do
+      git_support_mock.expect :current_tag, ''
+
+      assert_equal false, generator.should_generate?
+    end
+
+  end
+end


### PR DESCRIPTION
This is the first step in updating the emberjs.com/builds site's various channel sections to know about which version it is mirroring. The idea is to be able to let people know what the last tagged version for a given channel was.

This PR will generate a file in each 'channel' directory with the following directory structure:

```
/release/<dasherized project name>-version.json
/beta/<dasherized project name>-version.json
/canary/<dasherized project name>-version.json
```

The contents of each file will be:

``` json
{
    "projectName": "Ember Data",
    "projectFilter": "ember-data",
    "lastRelease": "1.1.0-beta.1",
    "futureVersion": "1.1.0",
    "channel": "beta",
    "date": "2013-09-13"
}
```

A companion PR will be submitted to the website shortly...
