### PR TITLE
Add GitSupport#master_revision.

### DIFF
--- a/lib/ember-dev/git_support.rb
+++ b/lib/ember-dev/git_support.rb
@@ -30,6 +30,12 @@ module EmberDev
       git_command("git rev-list HEAD -n 1")
     end
 
+    def master_revision
+      git_command("git ls-remote --heads origin master")
+        .split(/\s/)
+        .first
+    end
+
     def current_branch
       branches_containing_commit.first
     end
@@ -39,7 +45,7 @@ module EmberDev
     end
 
     def commit_range
-      current_revision + '...master'
+        master_revision + '...' + current_revision
     end
 
     def checkout(branch)
@@ -67,7 +73,7 @@ module EmberDev
       git_command("git branch --all --contains #{current_revision}")
         .split("\n")
         .reject{|r| r =~ /detached/ } # get rid of any entries for detached head
-        .collect{|r| r.gsub(/\W/, '') }
+        .collect{|r| r.gsub(/[\s\*]/, '') }
     end
 
     def git_command(command_to_run)

--- a/spec/unit/git_support_spec.rb
+++ b/spec/unit/git_support_spec.rb
@@ -115,12 +115,36 @@ describe EmberDev::GitSupport do
   end
 
   describe "the range of commits since master" do
-    let(:repo_path) { standard_repo_on_branch }
+    let(:repo_path) { Pathname.new(tmpdir).join('clone_path') }
 
-    it "should return a string representing the range from the current commit to master" do
-      expected_result = git_support.current_revision + '...master'
+    before do
+      `git clone --quiet file://#{standard_repo_on_branch.realpath} #{repo_path}`
+    end
 
-     assert_equal expected_result, git_support.commit_range
+    it "should return a string representing the range from the current commit to the master revision" do
+      expected_result = git_support.master_revision + '...' + git_support.current_revision
+
+      assert_equal expected_result, git_support.commit_range
+    end
+  end
+
+  describe "Can determine the master revision" do
+    let(:repo_path) { tmpdir + '/clone_path' }
+
+    before do
+      `git clone --quiet file://#{standard_repo_on_branch.realpath} #{repo_path}`
+    end
+
+    it "returns the correct sha" do
+      base_repo_commits = commits_for_repo(standard_repo)
+
+      assert_equal base_repo_commits.first, git_support.master_revision
+    end
+
+    it "does not equal the current_revision" do
+      base_repo_commits = commits_for_repo(standard_repo)
+
+      refute_equal base_repo_commits.first, git_support.current_revision
     end
   end
 


### PR DESCRIPTION
The commit ranges that are provided to Travis are not valid (at least not from within the CI environment).  This adds the ability to determine the proper `master_revision` using `git ls-remote --heads origin master`.
