### PR TITLE
Do not use Travis variables in GitSupport.

### DIFF
--- a/lib/ember-dev/git_support.rb
+++ b/lib/ember-dev/git_support.rb
@@ -9,7 +9,6 @@ module EmberDev
       @env           = options.fetch(:env) { ENV }
       @debug         = options.fetch(:debug) { false }
       @git_version   = git_command('git --version')
-      @use_travis_environment_variables = options.fetch(:use_travis_environment_variables) { true }
 
       print_debugging_info if @debug
     end
@@ -23,30 +22,16 @@ module EmberDev
       puts "  commits: #{commits}"
     end
 
-    def use_travis_environment_variables
-      @use_travis_environment_variables &&
-        @env['TRAVIS'] &&
-        @env['TRAVIS_BUILD_DIR'] == repo_path.to_s
-    end
-
     def current_tag
       git_command "git tag --points-at #{current_revision}"
     end
 
     def current_revision
-      if use_travis_environment_variables
-        @env['TRAVIS_COMMIT']
-      else
-        git_command("git rev-list HEAD -n 1")
-      end
+      git_command("git rev-list HEAD -n 1")
     end
 
     def current_branch
-      if use_travis_environment_variables
-        @env['TRAVIS_BRANCH']
-      else
-        branches_containing_commit.first
-      end
+      branches_containing_commit.first
     end
 
     def make_shallow_clone_into_full_clone
@@ -54,11 +39,7 @@ module EmberDev
     end
 
     def commit_range
-      if use_travis_environment_variables
-        @env['TRAVIS_COMMIT_RANGE']
-      else
-        current_revision + '...master'
-      end
+      current_revision + '...master'
     end
 
     def checkout(branch)

--- a/spec/unit/git_support_spec.rb
+++ b/spec/unit/git_support_spec.rb
@@ -11,37 +11,7 @@ describe EmberDev::GitSupport do
   let(:standard_repo) { Pathname.new('spec/support/test_repos/standard_repo') }
   let(:standard_repo_on_branch) { Pathname.new('spec/support/test_repos/standard_repo_on_branch') }
 
-  let(:git_support) { EmberDev::GitSupport.new(repo_path, :use_travis_environment_variables => false) }
-
-  describe "Uses travis's enviroment variables when appropriate" do
-    let(:repo_path)   { standard_repo }
-
-    before do
-      git_support
-    end
-
-    it "uses them when the repo_path == the TRAVIS_BUILD_DIR" do
-      git_support = EmberDev::GitSupport.new(repo_path, :env => {
-        'TRAVIS' => 'true',
-        'TRAVIS_BUILD_DIR' => repo_path.realpath.to_s
-      })
-
-      in_repo_dir repo_path do
-        assert git_support.use_travis_environment_variables
-      end
-    end
-
-    it "doesn't use them when the repo_path isn't the TRAVIS_BUILD_DIR" do
-      git_support = EmberDev::GitSupport.new(repo_path, :env => {
-        'TRAVIS' => 'true',
-        'TRAVIS_BUILD_DIR' => standard_repo_on_branch.realpath.to_s
-      })
-
-      in_repo_dir standard_repo_on_branch do
-        refute git_support.use_travis_environment_variables
-      end
-    end
-  end
+  let(:git_support) { EmberDev::GitSupport.new(repo_path) }
 
   describe "Working on master branch with tag at HEAD" do
     let(:repo_path)   { standard_repo }
@@ -146,16 +116,6 @@ describe EmberDev::GitSupport do
 
   describe "the range of commits since master" do
     let(:repo_path) { standard_repo_on_branch }
-
-    it "should use the TRAVIS_COMMIT_RANGE variable if present" do
-      env = {'TRAVIS'              => 'true',
-             'TRAVIS_COMMIT_RANGE' => 'blardyblarblar',
-             'TRAVIS_BUILD_DIR'    => repo_path.realpath.to_s}
-
-      git_support = EmberDev::GitSupport.new(repo_path, :env => env)
-
-      assert_equal 'blardyblarblar', git_support.commit_range
-    end
 
     it "should return a string representing the range from the current commit to master" do
       expected_result = git_support.current_revision + '...master'


### PR DESCRIPTION
We were using the Travis variables in two areas:
- commit_range - The range actually provided by Travis (from GitHub's
  webhook to them) is not a valid commit range (can not do `git log
  <commit range>`)
- current_branch - We have added the logic to determine the current
  branch directly (to support multi-branch testing).

This ultimately removes some complexity, and resolves a number of build
failures that I have been dealing with when integrating the latest
ember-dev into Ember itself.
