### PR TITLE
Make static test site.

### DIFF
--- a/lib/ember-dev.rb
+++ b/lib/ember-dev.rb
@@ -9,6 +9,7 @@ module EmberDev
   autoload :TestRunner,  'ember-dev/test_runner'
   autoload :GitSupport,  'ember-dev/git_support'
 
+  autoload :TestSiteGenerator,            'ember-dev/test_site_generator'
   autoload :DocumentationGenerator,       'ember-dev/documentation_generator'
   autoload :ChannelReleasesFileGenerator, 'ember-dev/channel_releases_file_generator'
 

--- a/lib/ember-dev/asset.rb
+++ b/lib/ember-dev/asset.rb
@@ -87,6 +87,14 @@ module EmberDev
                             production_source => production_targets
       end
 
+      def content_type(extension = extension)
+        case extension
+        when '.js'   then 'text/javascript'
+        when '.json' then 'application/json'
+        when '.html' then 'text/html'
+        end
+      end
+
       private
 
       def strip_missing_files(hash)

--- a/lib/ember-dev/publish.rb
+++ b/lib/ember-dev/publish.rb
@@ -77,10 +77,6 @@ module EmberDev
 
         @bucket = @s3.buckets[bucket_name]
 
-        @s3_options = {
-          :content_type     => 'text/javascript',
-        }
-
         generator = ChannelReleasesFileGenerator.new
 
         if generator.should_generate?
@@ -98,7 +94,7 @@ module EmberDev
 
             unless pretend
               obj = @bucket.objects[subdirectory + target_file]
-              obj.write(source_file, @s3_options)
+              obj.write(source_file, {:content_type => asset_file.content_type})
             end
           end
         end

--- a/lib/ember-dev/server.rb
+++ b/lib/ember-dev/server.rb
@@ -31,7 +31,7 @@ module EmberDev
         end
       end
     end
-    
+
     class EmberData
       def initialize(app)
         @app = app
@@ -59,14 +59,14 @@ module EmberDev
     end
 
     class ErbIndex
-      def initialize(app, root)
+      def initialize(app)
         @app = app
-        @root = root
       end
 
       def call(env)
         if env['PATH_INFO'] == '/'
-          data = ERB.new(File.read(File.join(@root, 'index.html.erb'))).result
+          data = TestSiteGenerator.output
+
           [200, {'Content-Type' => 'text/html'}, [data]]
         else
           @app.call(env)
@@ -89,7 +89,7 @@ module EmberDev
         use EmberJS
         use EmberData
 
-        use ErbIndex, tests_root
+        use ErbIndex
         run Rack::Directory.new(tests_root)
       end
     end

--- a/lib/ember-dev/test_site_generator.rb
+++ b/lib/ember-dev/test_site_generator.rb
@@ -1,0 +1,60 @@
+require 'erb'
+require 'fileutils'
+
+module EmberDev
+  class TestSiteGenerator
+    attr_reader :template
+
+    def self.output(template = nil)
+      new(template: template).output
+    end
+
+    def initialize(options = nil)
+      options ||= {}
+
+      @static   = options.fetch(:static, false)
+      @template = options.fetch(:template, nil)
+    end
+
+    def template
+      @template ||= File.read(default_template_path)
+    end
+
+    def output
+      ERB.new(template).result(binding)
+    end
+
+    def save(path)
+      path = Pathname.new(path)
+      path.dirname.mkpath
+
+      path.open('w') { |io| io.write output }
+    end
+
+    def static?
+      @static
+    end
+
+    def qunit_configuration_source
+      asset_root_path.join('qunit_configuration.js').read
+    end
+
+    def minispade_source
+      asset_root_path.join('minispade.js').read
+    end
+
+    def jshint_source
+      asset_root_path.join('jshint.js').read
+    end
+
+    private
+
+    def asset_root_path
+      Pathname.new(__FILE__).join(*%w{.. .. .. support tests})
+    end
+
+    def default_template_path
+      asset_root_path.join('index.html.erb')
+    end
+  end
+end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -26,6 +26,13 @@ namespace :ember do
     end
   end
 
+  desc "Generate a static test site."
+  task :generate_static_test_site => :dist do
+    generator = EmberDev::TestSiteGenerator.new(static: true)
+
+    generator.save('dist/tests.html')
+  end
+
   desc "Automatically run tests (Mac OS X only)"
   task :autotest do
     sh("kicker -e 'rake test' packages")

--- a/spec/support/site_generator/support/tests/index.html.erb
+++ b/spec/support/site_generator/support/tests/index.html.erb
@@ -1,0 +1,1 @@
+Static Test Site <%= 'non-random value' %>

--- a/spec/unit/asset_spec.rb
+++ b/spec/unit/asset_spec.rb
@@ -174,4 +174,18 @@ describe EmberDev::Publish::Asset do
       end
     end
   end
+
+  describe 'content_type' do
+    it "returns text/html for *.html files" do
+      assert_equal 'text/html', asset_file.content_type('.html')
+    end
+
+    it "returns text/javascript for *.js files" do
+      assert_equal 'text/javascript', asset_file.content_type('.js')
+    end
+
+    it "returns application/json for *.json files" do
+      assert_equal 'application/json', asset_file.content_type('.json')
+    end
+  end
 end

--- a/spec/unit/test_site_generator_spec.rb
+++ b/spec/unit/test_site_generator_spec.rb
@@ -1,0 +1,88 @@
+require 'fileutils'
+require 'securerandom'
+require 'minitest/autorun'
+
+require_relative '../support/tmpdir_helpers'
+require_relative '../../lib/ember-dev'
+
+module EmberDev
+  describe TestSiteGenerator do
+    include TmpdirHelpers
+
+    let(:random_string) { SecureRandom.base64(50) }
+    let(:mock_template) { "<%= '#{random_string}' %>" }
+    let(:support_test_dir) { Pathname.new(__FILE__).join('..', '..', '..','support','tests') }
+    let(:real_template_path) { support_test_dir.join('index.html.erb') }
+
+    let(:generator) { TestSiteGenerator.new(template: mock_template) }
+
+    describe "#static_build?" do
+      it "is true when option passed to initialize" do
+        generator = TestSiteGenerator.new(template: mock_template, static: true)
+
+        assert generator.static?, 'static? should be true'
+      end
+
+      it "is false when no option is passed to initialize" do
+        generator = TestSiteGenerator.new(template: mock_template)
+
+        refute generator.static?, 'static? should be false'
+      end
+    end
+
+    describe 'template' do
+      it "accepts a template" do
+        generator = TestSiteGenerator.new(template: mock_template)
+
+        assert_equal mock_template, generator.template
+      end
+
+      it "reads support/tests/index.html.erb if no template is specified" do
+        Dir.chdir tmpdir do
+          generator = TestSiteGenerator.new
+
+          assert_equal File.read(real_template_path), generator.template
+        end
+      end
+    end
+
+    describe '#output' do
+      it "uses template to generate output" do
+        assert_equal random_string, generator.output
+      end
+
+      it "passes the current binding into the template" do
+        mock_template = "Class: <%= self.class %>"
+        generator = TestSiteGenerator.new(template: mock_template, static: true)
+
+        assert_equal "Class: EmberDev::TestSiteGenerator", generator.output
+      end
+    end
+
+    describe "#save" do
+      it "creates a file at the specified path with the templates output" do
+        generator.save(tmpdir + '/tests.html')
+
+        assert_equal File.read(tmpdir + '/tests.html'), random_string
+      end
+    end
+
+    it "returns the qunit_configuration" do
+      expected_output = support_test_dir.join('qunit_configuration.js').read
+
+      assert expected_output == generator.qunit_configuration_source
+    end
+
+    it "returns the minispade source" do
+      expected_output = support_test_dir.join('minispade.js').read
+
+      assert expected_output == generator.minispade_source
+    end
+
+    it "returns the jshint source" do
+      expected_output = support_test_dir.join('jshint.js').read
+
+      assert expected_output == generator.jshint_source
+    end
+  end
+end

--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -3,9 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <title><%= EmberDev.config.name %> Test Suite</title>
-  <link rel="stylesheet" href="qunit/qunit.css" type="text/css" media="screen">
-  <script type="text/javascript" src="qunit/qunit.js"></script>
-  <script type="text/javascript" src="minispade.js"></script>
+  <% if static? %>
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.12.0.css" type="text/css" media="screen">
+    <script type="text/javascript" src="https://code.jquery.com/qunit/qunit-1.12.0.js"></script>
+    <script type="text/javascript"><%= minispade_source %></script>
+  <% else %>
+    <link rel="stylesheet" href="qunit/qunit.css" type="text/css" media="screen">
+    <script type="text/javascript" src="qunit/qunit.js"></script>
+    <script type="text/javascript" src="minispade.js"></script>
+  <% end %>
+
 
   <script type="text/javascript">
     window.loadScript = function(url) {
@@ -45,7 +52,13 @@
     };
   </script>
 
-  <script type="text/javascript" src="qunit_configuration.js"></script>
+  <% if static? %>
+    <script type="text/javascript">
+      <%= qunit_configuration_source %>
+    </script>
+  <% else %>
+    <script type="text/javascript" src="qunit_configuration.js"></script>
+  <% end %>
 </head>
 <body>
   <h1 id="qunit-header"><%= EmberDev.config.name %> Test Suite</h1>
@@ -57,7 +70,11 @@
 
   <script type="text/javascript">
     if (EmberDev.jsHint) {
-      loadScript('jshint.js');
+      <% if static? %>
+        <%= jshint_source %>
+      <% else %>
+        loadScript('jshint.js');
+      <% end %>
     }
     // Close the script tag to make sure document.write happens
   </script>
@@ -66,7 +83,7 @@
     // Load custom version of jQuery if possible (assign to window so IE8 can use in later blocks)
     var jQueryVersion = QUnit.urlParams.jquery || "1.10.2";
     if (jQueryVersion !== 'none') {
-      loadScript('http://code.jquery.com/jquery-'+jQueryVersion+'.js');
+      loadScript('https://code.jquery.com/jquery-'+jQueryVersion+'.js');
     }
     // Close the script tag to make sure document.write happens
   </script>
@@ -85,7 +102,11 @@
     var handlebarsVersion = QUnit.urlParams.handlebars;
 
     if (handlebarsVersion !== 'none') {
-      loadScript('/handlebars.js');
+      <% if static? %>
+        loadScript('http://builds.emberjs.com/handlebars-1.0.0.js');
+      <% else %>
+        loadScript('/handlebars.js');
+      <% end %>
     }
     // Close the script tag to make sure document.write happens
   </script>


### PR DESCRIPTION
Running the following from the ember repo should result in a static file to
run the test suite on:

Rake task:

```
rake ember:generate_static_test_site
```

Manually (make sure to run `rake dist` first):

``` ruby
require 'bundler/setup'
require 'ember-dev'

generator = EmberDev::TestSiteGenerator.new(static: true) 
generator.save('dist')
```

This is an initial step in getting Sauce Labs integration working. Once
we have a static site for our tests, we can use Sauce Lab's REST API to
manage jobs.

Using this static site results in a fully passing suite under both Chrome and Safari (for Ember).
