### PR TITLE
Use the correct project name in the CHANGELOG.

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -1,4 +1,5 @@
 PROJECT_VERSION = File.read("VERSION").strip
+require 'ember-dev'
 
 namespace :ember do
   namespace :release do
@@ -17,11 +18,11 @@ namespace :ember do
       last_tag = `git describe --tags --abbrev=0`.strip
       puts "Getting Changes since #{last_tag}"
 
-      cmd = "git log #{last_tag}..HEAD --format='* %s'"
+      cmd = "git log #{last_tag}..HEAD --format='  * %s'"
 
       changes = `#{cmd}`
 
-      output = "*Ember #{PROJECT_VERSION} (#{Time.now.strftime("%B %d, %Y")})*\n\n#{changes}\n"
+      output = "* #{EmberDev.config.name} #{PROJECT_VERSION} (#{Time.now.strftime("%B %d, %Y")})*\n\n#{changes}\n"
 
       unless pretend?
         open('CHANGELOG', 'r+') do |file|


### PR DESCRIPTION
- Uses the EmberDev.config.name for outputting the `CHANGELOG` (was
  previously hard-coded to `Ember`).
- Make changelog entries indented under the release title.
