### PR TITLE
Allow overriding build_type.

### DIFF
--- a/lib/ember-dev/publish.rb
+++ b/lib/ember-dev/publish.rb
@@ -30,6 +30,8 @@ module EmberDev
       when 'stable','release' then :release
       when 'beta'             then :beta
       when 'master'           then :canary
+      else
+        ENV['BUILD_TYPE'] && ENV['BUILD_TYPE'].to_sym
       end
     end
 


### PR DESCRIPTION
This is useful for testing the various publishing tasks on branches other than
master/beta/stable.
