### PR TITLE
Use SSL for handlebars for static site.

### DIFF
--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -103,7 +103,7 @@
 
     if (handlebarsVersion !== 'none') {
       <% if static? %>
-        loadScript('http://builds.emberjs.com/handlebars-1.0.0.js');
+        loadScript('https://s3.amazonaws.com/builds.emberjs.com/handlebars-1.0.0.js');
       <% else %>
         loadScript('/handlebars.js');
       <% end %>


### PR DESCRIPTION
Fixes error in Sauce Labs testing when test site is loaded via SSL.
