### PR TITLE
Remove `which` calls.

### DIFF
--- a/lib/ember-dev/documentation_generator.rb
+++ b/lib/ember-dev/documentation_generator.rb
@@ -34,7 +34,7 @@ module EmberDev
     end
 
     def yuidoc_available?
-      system("which yuidoc > /dev/null 2>&1")
+      system("yuidoc --version > /dev/null 2>&1")
     end
 
     def run_yuidoc

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,11 +1,11 @@
 namespace :ember do
   desc "Run tests with phantomjs"
   task :test, [:suite] => :dist do |t, args|
-    unless sh("which phantomjs > /dev/null 2>&1")
+    unless sh("phantomjs --version > /dev/null 2>&1")
       abort "PhantomJS is not installed. Download from http://phantomjs.org"
     end
 
-    if File.exists?('features.json') && !sh("which defeatureify > /dev/null 2>&1")
+    if File.exists?('features.json') && !sh("defeatureify --version > /dev/null 2>&1")
       abort "You have a `features.json` file, but defeatureify is not installed. You can install it with:\nnpm install -g defeatureify."
     end
 


### PR DESCRIPTION
Swap out any `which` calls to simply call the executable with a noop option
(`--version`).

This requires https://github.com/thomasboyt/defeatureify/pull/1.

Fixes #54.
