### PR TITLE
Use the project name as a prefix for test files.

### DIFF
--- a/lib/ember-dev/config.rb
+++ b/lib/ember-dev/config.rb
@@ -22,5 +22,9 @@ module EmberDev
       @assetfile ||= EmberDev.support_path.join("Assetfile").to_s
       @testing_packages ||= []
     end
+
+    def dasherized_name
+      name.downcase.gsub(' ','-')
+    end
   end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../lib/ember-dev'
+
+module EmberDev
+  describe Config do
+
+    describe "can convert project names to dasherized version" do
+      it "handles Ember Data properly" do
+        config = Config.new name: 'Ember Data'
+
+        assert_equal 'ember-data', config.dasherized_name
+      end
+
+      it "handles Ember properly" do
+        config = Config.new name: 'Ember'
+
+        assert_equal 'ember', config.dasherized_name
+      end
+    end
+  end
+end

--- a/support/Assetfile
+++ b/support/Assetfile
@@ -1,5 +1,6 @@
 Encoding.default_external = "UTF-8" if defined?(Encoding)
 
+require 'ember-dev'
 require "ember-dev/rakep/filters"
 
 output "dist"
@@ -14,10 +15,10 @@ input "packages" do
       id
     }
 
-    concat "ember-tests.js"
+    concat "#{EmberDev.config.dasherized_name}-tests.js"
   end
 
-  match "ember-tests.js" do
+  match  "#{EmberDev.config.dasherized_name}-tests.js" do
     filter JSHintRC
   end
 end

--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -218,7 +218,7 @@
     </script>
   <% end %>
 
-  <script type="text/javascript" src="ember-tests.js"></script>
+  <script type="text/javascript" src="<%= EmberDev.config.dasherized_name %>-tests.js"></script>
 
   <script type="text/javascript">
     // Load Tests and Depenencies


### PR DESCRIPTION
Fixes issue where ember-data test file was named `ember-tests.js`. Once we are
publishing the tests along with each build, this would cause them to overwrite
each other.
