### PR TITLE
Run tests on local repo ONLY unless CI=true.

### DIFF
--- a/lib/ember-dev/test_support.rb
+++ b/lib/ember-dev/test_support.rb
@@ -8,6 +8,7 @@ module EmberDev
       @debug          = options.fetch(:debug)            { true }
       @selected_suite = options.fetch(:selected_suite)   { 'default' }
       @git_support    = options.fetch(:git_support)      { GitSupport.new('.', :debug => @debug) }
+      @multi_branch   = options.fetch(:enable_multi_branch_tests) { false }
     end
 
     def packages
@@ -23,8 +24,9 @@ module EmberDev
     end
 
     def run_all
-      puts 'Running tests on master' if debug
+      puts "Running tests on #{git_support.current_branch}" if debug
       return false unless run_all_tests_on_current_revision
+      return true unless @multi_branch
 
       branches_to_test.all? do |branch|
         prepare_for_branch_tests(branch) && run_all_tests_on_current_revision

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -11,6 +11,7 @@ namespace :ember do
 
     params = {}
     params[:selected_suite] = args[:suite] if args[:suite]
+    params[:enable_multi_branch_tests] = true if ENV['CI']
 
     test_support = EmberDev::TestSupport.new(params)
 


### PR DESCRIPTION
This prevents a super annoying bug that was causing local repos to be broken (due to the cherry-picking).

After this change you will need to have set `ENV['CI']` to enable running multi-branch testing.  This environment variable is set by default in TravisCI so we should not need to change the Travis `script` for the parent projects.
