### PR TITLE
Do not make assumptions about features.json.

### DIFF
--- a/lib/ember-dev/test_support.rb
+++ b/lib/ember-dev/test_support.rb
@@ -82,10 +82,6 @@ module EmberDev
       @commits_by_branch = ret
     end
 
-    def features_file_is_available?
-      File.exists?('features.json')
-    end
-
     private
 
     def build_suites
@@ -119,9 +115,7 @@ module EmberDev
       packages.each do |package|
         output << "package=#{package}"
 
-        unless features_file_is_available?
-          output << "package=#{package}&enableallfeatures=true"
-        end
+        output << "package=#{package}&enableoptionalfeatures=true"
       end
 
       output

--- a/spec/unit/test_support_spec.rb
+++ b/spec/unit/test_support_spec.rb
@@ -50,46 +50,20 @@ describe EmberDev::TestSupport do
     end
 
     describe "adds each package individually to suite runs if EACH_PACKAGE is found" do
-      it "tests with features on and off if no `features.json` file is found" do
+      it "tests with features on and off" do
         testing_suites = {'each' => ['EACH_PACKAGE']}
         EmberDev.config.testing_suites = testing_suites
-
-        def support.features_file_is_available?; false; end
 
         suites = support.suites
         expected_runs = []
 
         fake_packages.each do |package|
           expected_runs << "package=#{package}"
-          expected_runs << "package=#{package}&enableallfeatures=true"
+          expected_runs << "package=#{package}&enableoptionalfeatures=true"
         end
 
         assert_equal expected_runs, suites['each']
       end
-
-      it "if `features.json` file is found it does not test with enableallfeatures" do
-        testing_suites = {'each' => ['EACH_PACKAGE']}
-        EmberDev.config.testing_suites = testing_suites
-
-        def support.features_file_is_available?; true; end
-
-        suites = support.suites
-        expected_runs = []
-
-        fake_packages.each do |package|
-          expected_runs << "package=#{package}"
-        end
-
-        assert_equal expected_runs, suites['each']
-      end
-    end
-  end
-
-  it "knows when a features_file_is_available?" do
-    refute support.features_file_is_available?
-
-    Dir.chdir 'spec/support' do
-      assert support.features_file_is_available?
     end
   end
 

--- a/spec/unit/version_calculator_spec.rb
+++ b/spec/unit/version_calculator_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../lib/ember-dev/version_calculator'
 
 module EmberDev
   describe VersionCalculator do
-    include TestSupport::TmpdirHelpers
+    include TmpdirHelpers
 
     let(:calc) { VersionCalculator.new options}
     let(:options) do

--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -172,12 +172,17 @@
     // Close the script tag to make sure document.write happens
   </script>
 
-  <% if File.exists?("features.json") %>
-    <script type="text/javascript">
-      window.ENV = window.ENV || {};
+  <script type="text/javascript">
+    // Handle testing feature flags
+    window.ENV = window.ENV || {};
+
+    <% if File.exists?("features.json") %>
       window.ENV.FEATURES = <%= File.read("features.json") %>
-    </script>
-  <% end %>
+    <% end %>
+
+    QUnit.config.urlConfig.push({ id: 'enableoptionalfeatures', label: "Enable Opt Features"});
+    window.ENV['ENABLE_OPTIONAL_FEATURES'] = !!QUnit.urlParams.enableoptionalfeatures;
+  </script>
 
   <% if File.exist?("tests/ember_configuration.js") %>
     <script type="text/javascript">


### PR DESCRIPTION
This removes the automatic assumption by `ember-dev` that if a features.json exists we should not test all features.

Also, uses the new `ENABLE_OPTIONAL_FEATURES` instead of `ENABLE_ALL_FEATURES` to ensure that any features explicitly enabled are still enabled in the tests.
