### PR TITLE
Enable testing against multiple Ember versions.

### DIFF
--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -191,14 +191,21 @@
   <% end %>
 
   <% unless EmberDev.config.testing_ember %>
-      <script type="text/javascript">
-        <% if static? %>
-          loadScript('https://s3.amazonaws.com/builds.emberjs.com/release/ember.js');
-        <% else %>
-          loadScript('/ember.js');
-        <% end %>
-        // Close the script tag to make sure document.write happens
-      </script>
+    <script type="text/javascript">
+      var emberChannel = QUnit.urlParams.emberchannel || "release", emberPath;
+
+      <% if !static? && defined?(Ember::Source) %>
+        if (emberChannel === "release") {
+          emberPath = '/ember.js';
+        }
+      <% end %>
+
+      if (!emberPath) {
+        emberPath = 'https://s3.amazonaws.com/builds.emberjs.com/' + emberChannel + '/ember.js';
+      }
+
+      loadScript(emberPath);
+    </script>
   <% end %>
 
   <% if EmberDev.config.testing_needs_ember_data %>


### PR DESCRIPTION
If `Ember::Source` is defined and we are testing against the `release` channel, use the local version of Ember from the `ember_source` gem. Otherwise, use the published builds from S3 for the proper channel.

This is the basis for allowing testing against multiple versions of Ember from within Ember Data.
