### PR TITLE
Ensure templates and views are not leaking.

### DIFF
--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -20,35 +20,49 @@
       document.write(unescape('%3Cscript src="'+url+'"%3E%3C/script%3E'));
     };
 
-    var EmberDev = {};
+    var EmberDev = {}, originalViews, originalTemplates;
 
-    EmberDev.afterEach = function() {
-      if (Ember && Ember.View) {
-        var viewIds = [], id;
-        for (id in Ember.View.views) {
-          if (Ember.View.views[id] != null) {
-            viewIds.push(id);
+    EmberDev.beforeEach = function(){
+      function clone(obj){
+        var target = {};
+        for (var i in obj) {
+          if (obj.hasOwnProperty(i)) {
+            target[i] = obj[i];
           }
         }
+        return target;
+      }
 
-        if (viewIds.length > 0) {
-          deepEqual(viewIds, [], "Ember.View.views should be empty");
-          Ember.View.views = [];
-        }
+      if (Ember && Ember.View) {
+        originalViews = clone(Ember.View.views);
       }
 
       if (Ember && Ember.TEMPLATES) {
-        var templateNames = [], name;
-        for (name in Ember.TEMPLATES) {
-          if (Ember.TEMPLATES[name] != null) {
-            templateNames.push(name);
+        originalTemplates = clone(Ember.TEMPLATES);
+      }
+    }
+
+    EmberDev.afterEach = function() {
+      if (Ember && Ember.View) {
+        var id;
+        for (id in Ember.View.views) {
+          if (!QUnit.equiv(Ember.View.views[id], originalViews[id])) {
+            ok(false, "Ember.View.views['" + id + "'] has changed from its original value.");
           }
         }
 
-        if (templateNames.length > 0) {
-          deepEqual(templateNames, [], "Ember.TEMPLATES should be empty");
-          Ember.TEMPLATES = {};
+        Ember.View.views = originalViews;
+      }
+
+      if (Ember && Ember.TEMPLATES) {
+        var name;
+        for (name in Ember.TEMPLATES) {
+          if (!QUnit.equiv(Ember.TEMPLATES[name], originalTemplates[name])) {
+            ok(false, "Ember.TEMPLATES['" + name + "'] has changed from its original value.");
+          }
         }
+
+        Ember.TEMPLATES = originalTemplates;
       }
     };
   </script>

--- a/support/tests/qunit_configuration.js
+++ b/support/tests/qunit_configuration.js
@@ -19,7 +19,15 @@
   var originalModule = module;
   module = function(name, origOpts) {
     var opts = {};
-    if (origOpts && origOpts.setup) { opts.setup = origOpts.setup; }
+
+    opts.setup = function() {
+      if (EmberDev.beforeEach) {
+        EmberDev.beforeEach();
+      }
+
+      if (origOpts && origOpts.setup) { origOpts.setup(); }
+    }
+
     opts.teardown = function() {
       if (origOpts && origOpts.teardown) { origOpts.teardown(); }
 


### PR DESCRIPTION
Currently, we are assuming that `Ember.TEMPLATES` and `Ember.View.views` 
should be empty. This changes that assumption to allow the intial values
(before tests are run) to exist after the tests are completed. This more 
accurately reflects the original intent of preventing tests from leaking 
views/templates.
