### PR TITLE
Ensure that we `rake dist` prior to running tests.

### DIFF
--- a/ember-dev.gemspec
+++ b/ember-dev.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "execjs"
   gem.add_dependency "aws-sdk"
   gem.add_dependency "puma"
+  gem.add_dependency "childprocess"
 
   gem.add_development_dependency "minitest", '~> 5.0.0'
 end

--- a/lib/ember-dev/test_support.rb
+++ b/lib/ember-dev/test_support.rb
@@ -39,10 +39,18 @@ module EmberDev
       puts "Checking out: #{branch}" if debug
       return false unless git_support.checkout(branch)
 
-      commits_by_branch[branch].all? do |commit|
+      return false unless commits_by_branch[branch].all? do |commit|
         puts "Cherry picking #{commit} into #{branch}" if debug
         git_support.cherry_pick(commit)
       end
+
+      build
+    end
+
+    def build
+      backtick("bundle exec rake ember:dist")
+
+      $?.success?
     end
 
     def run_all_tests_on_current_revision
@@ -119,6 +127,11 @@ module EmberDev
       end
 
       output
+    end
+
+    def backtick(command)
+      puts "Running: #{command}"
+      puts `#{command}`
     end
   end
 end

--- a/spec/unit/test_support_spec.rb
+++ b/spec/unit/test_support_spec.rb
@@ -166,12 +166,26 @@ describe EmberDev::TestSupport do
       git_support_mock.expect(:cherry_pick, true, ['d9afd8d6d5cbe7b'])
       git_support_mock.expect(:make_shallow_clone_into_full_clone, true)
 
+      def support.build; @build_called = true; end
+      def support.build_called; @build_called; end
+
       support.prepare_for_branch_tests('beta')
 
       git_support_mock.verify
+      assert support.build_called
     end
   end
 
+  describe "builds the project" do
+    it "calls `rake dist` to build the project" do
+      def support.backtick(arg); @backtick_calls ||= []; @backtick_calls << arg; end
+      def support.backtick_calls; @backtick_calls; end
+
+      support.build
+
+      assert_equal ["bundle exec rake ember:dist"], support.backtick_calls
+    end
+  end
 
   describe "iterates over each branch and runs tests" do
     let(:git_support_mock) { Minitest::Mock.new }


### PR DESCRIPTION
This fixes an issue that occurs on Travis after we checkout a new branch.
Previously, the builds would timeout due to CPU contention with
`phantomjs`, `defeautureify`, and `puma` all running at once (Travis only
provides 1.5 CPU's).
