### PR TITLE
Allow forcing tests to run on a specific branch.

### DIFF
--- a/lib/ember-dev/test_support.rb
+++ b/lib/ember-dev/test_support.rb
@@ -8,6 +8,7 @@ module EmberDev
       @debug          = options.fetch(:debug)            { true }
       @selected_suite = options.fetch(:selected_suite)   { 'default' }
       @git_support    = options.fetch(:git_support)      { GitSupport.new('.', :debug => @debug) }
+      @force_branch   = options.fetch(:force_branch)     { nil }
       @multi_branch   = options.fetch(:enable_multi_branch_tests) { false }
     end
 
@@ -24,6 +25,15 @@ module EmberDev
     end
 
     def run_all
+      if @force_branch
+        if branches_to_test.include?(@force_branch)
+          return prepare_for_branch_tests(@force_branch) && run_all_tests_on_current_revision
+        else
+          puts "No commits for #{@force_branch}." if debug
+          return true
+        end
+      end
+
       puts "Running tests on #{git_support.current_branch}" if debug
       return false unless run_all_tests_on_current_revision
       return true unless @multi_branch

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -12,6 +12,10 @@ namespace :ember do
       params[:enable_multi_branch_tests] = true
     end
 
+    if ENV['FORCE_BRANCH']
+      params[:force_branch] = ENV['FORCE_BRANCH']
+    end
+
     test_support = EmberDev::TestSupport.new(params)
 
     unless test_support.test_runs


### PR DESCRIPTION
This will be used in the Ember test suite to prevent running the suite on
multiple branches in the same test run.
