### PR TITLE
Make `defeatureify` commands windows friendly

### DIFF
--- a/lib/ember-dev/rakep/filters.rb
+++ b/lib/ember-dev/rakep/filters.rb
@@ -178,7 +178,7 @@ class EmberDefeatureify < Rake::Pipeline::Filter
   def generate_output(inputs, output)
     inputs.each do |input|
       src = if File.exists?('features.json') && File.exists?('node_modules/.bin/defeatureify')
-              `./node_modules/.bin/defeatureify #{input.fullpath} -w features.json`
+              `node ./node_modules/.bin/defeatureify #{input.fullpath} -w features.json`
             else
               input.read
             end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -13,7 +13,7 @@ def ensure_defeatureify
   end
 
   required_version  = '~> 0.1.4'
-  installed_version = `#{command_path} --version`.chomp
+  installed_version = `node #{command_path} --version`.chomp
 
   unless Gem::Requirement.new(required_version) =~ Gem::Version.new(installed_version)
     abort "`defeatureify` (#{required_version}) is required, but we found (#{installed_version}) in '#{command_path}'. You can install it with:\n\tnpm install defeatureify"

--- a/spec/integration/documentation_generator_spec.rb
+++ b/spec/integration/documentation_generator_spec.rb
@@ -25,7 +25,7 @@ describe "Can generate the appropriate YUIDocs" do
 
       FileUtils.rm_rf 'docs/build'
 
-      system('cd docs && ../node_modules/yuidocjs/lib/cli.js -p -q')
+      system('cd docs && node ../node_modules/.bin/yuidoc -p -q')
 
       expected_docs = File.read('docs/build/data.json')
 


### PR DESCRIPTION
This is related to https://github.com/emberjs/ember.js/issues/4027.

Currently, building Ember with `rake dist` on Windows fails because it is unable to execute the `defeatureify` command using `node_modules/defeatureify/bin/cli.js`. 

I changed it to `node_modules/.bin/defeatureify` instead, which ends up invoking `node_modules/defeatureify/bin/cli.js` with `node` correctly. It's working fine for me on Windows now, but of course, I can't verify on a non-Windows machine =).
