### PR TITLE
Use defeatureify to strip debug messages.

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -12,7 +12,7 @@ def ensure_defeatureify
     abort "You have a `features.json` file, but defeatureify is not installed. You can install it with:\n\tnpm install defeatureify"
   end
 
-  required_version  = '~> 0.1.4'
+  required_version  = '~> 0.2.0'
   installed_version = `#{command_path} --version`.chomp
 
   unless Gem::Requirement.new(required_version) =~ Gem::Version.new(installed_version)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "defeatureify": "~0.1.4",
+    "defeatureify": "~0.2.0",
     "yuidocjs": "~0.3.46"
   }
 }


### PR DESCRIPTION
Recent changes to `defeatureify` allow stripping of debug messages. This will
allow us to use multi-line debug messages (for example).

To enable this the format of `features.json` has changed.

Before:

``` javascript
{
 "foo-feature": true
}
```

After:

``` javascript
{
 "features": {
   "foo-feature": true
 },
 "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate",
"Ember.debug", "Ember.Logger.info"]
}
```

---

This PR requires changes to be made to Ember's `feature.json` so the integration tests will fail. I have tested locally with a patched version of Ember and all tests pass. Once this is merged I will submit the corresponding PR to Ember to update the `features.json` properly.

---

Requires https://github.com/thomasboyt/defeatureify/pull/8 to be merged and `defeatureify` 0.2.0 to be published.
