### PR TITLE
Strip wrapper on features.

### DIFF
--- a/lib/ember-dev/test_site_generator.rb
+++ b/lib/ember-dev/test_site_generator.rb
@@ -1,4 +1,5 @@
 require 'erb'
+require 'json'
 require 'fileutils'
 
 module EmberDev
@@ -45,6 +46,13 @@ module EmberDev
 
     def jshint_source
       asset_root_path.join('jshint.js').read
+    end
+
+    def features
+      return "{}" unless File.exist?('features.json')
+
+      json = JSON.parse(File.read('features.json'))
+      json['features'].to_json
     end
 
     private

--- a/spec/support/features.json
+++ b/spec/support/features.json
@@ -1,0 +1,1 @@
+{"features":{"blah-feature":true}}

--- a/spec/unit/test_site_generator_spec.rb
+++ b/spec/unit/test_site_generator_spec.rb
@@ -84,5 +84,13 @@ module EmberDev
 
       assert expected_output == generator.jshint_source
     end
+
+    it "returns the features portion of features.json" do
+      expected_output = '{"blah-feature":true}'
+
+      Dir.chdir 'spec/support' do
+        assert_equal generator.features, expected_output
+      end
+    end
   end
 end

--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -176,9 +176,7 @@
     // Handle testing feature flags
     window.ENV = window.ENV || {};
 
-    <% if File.exists?("features.json") %>
-      window.ENV.FEATURES = <%= File.read("features.json") %>
-    <% end %>
+    window.ENV.FEATURES = <%= features %>
 
     QUnit.config.urlConfig.push({ id: 'enableoptionalfeatures', label: "Enable Opt Features"});
     window.ENV['ENABLE_OPTIONAL_FEATURES'] = !!QUnit.urlParams.enableoptionalfeatures;


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/emberjs/ember-dev/pull/118.

We changed the `features.json` format, but didn't strip the wrapping from the
values provided to `Ember.FEATURES`.
