### PR TITLE
Hide passed tests by default.

### DIFF
--- a/support/tests/qunit_configuration.js
+++ b/support/tests/qunit_configuration.js
@@ -48,6 +48,9 @@
   // Tests should time out after 5 seconds
   QUnit.config.testTimeout = 5000;
 
+  // Hide passed tests by default
+  QUnit.config.hidepassed = true;
+
   // Handle JSHint
   QUnit.config.urlConfig.push('nojshint');
 


### PR DESCRIPTION
This significantly improves test speed.
