### PR TITLE
Silence deprecate in tests

### DIFF
--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -315,7 +315,12 @@
     if (!test) {
       ok(false, 'Assertion failed: ' + msg);
     }
-  }
+  };
+  // Make Ember.deprecate quiet, unless RAISE_ON_DEPRECATION
+  Ember.deprecate = function(message, test) {
+    if (test) { return; }
+    if (Ember.ENV.RAISE_ON_DEPRECATION) { throw new Ember.Error(message); }
+  };
   </script>
 
 </body>


### PR DESCRIPTION
With all the inconsistent deprecation silencers cleaned up, there is a bunch of noise during test runs. As a quick fix, we can just overwrite deprecate to be quieter.

![](https://api.monosnap.com/image/download?id=Oeeb8pEUmHAO39uBuYphcpQf6)

Note that this keeps the `Ember.ENV.RAISE_ON_DEPRECATION` check- that is needed for one test in Ember doing a negative assertion on deprecations.

I think we can build a better solution shortly.
