### PR TITLE
Introduce a new async deprecation helper

### DIFF
--- a/support/tests/index.html.erb
+++ b/support/tests/index.html.erb
@@ -20,9 +20,9 @@
       document.write(unescape('%3Cscript src="'+url+'"%3E%3C/script%3E'));
     };
 
-    var EmberDev = {};
+    var EmberDev = { assertions: {}, deprecations: {} };
 
-    EmberDev.afterEach = function() {
+    EmberDev.assertions.noViewsRemain = function(){
       if (Ember && Ember.View) {
         var viewIds = [], id;
         for (id in Ember.View.views) {
@@ -36,7 +36,9 @@
           Ember.View.views = [];
         }
       }
+    };
 
+    EmberDev.assertions.noTemplatesRemain = function(){
       if (Ember && Ember.TEMPLATES) {
         var templateNames = [], name;
         for (name in Ember.TEMPLATES) {
@@ -50,6 +52,16 @@
           Ember.TEMPLATES = {};
         }
       }
+    };
+
+    EmberDev.assertions.noExpectedDeprecations = function(){
+      window.assertDeprecation();
+    };
+
+    EmberDev.afterEach = function() {
+      EmberDev.assertions.noViewsRemain();
+      EmberDev.assertions.noTemplatesRemain();
+      EmberDev.assertions.noExpectedDeprecations();
     };
   </script>
 


### PR DESCRIPTION
Let's get all crazy. @stefanpenner et. al.

This adds a far more robust `expectDeprecation` helper than Ember tests had previously. It adds any expectations to an array, and logs any deprecations on another. After every test, it check all the expectations against all the deprecations to see if any do not match up. Here is the most common use:

```
test("A templateName specified to a component is moved to the layoutName", function(){
  expectDeprecation(/Do not specify templateName on a Component, use layoutName instead/);
  component = Ember.Component.extend({
    templateName: 'blah-blah'
  }).create();

  equal(component.get('layoutName'), 'blah-blah', "The layoutName now contains the templateName specified.");
});
```

But this is backward compatible to the old accept-a-function method.

Once this is in, I can make a PR on Ember.js [using this new method most everywhere possible](https://github.com/mixonic/ember.js/compare/emberjs:master...mixonic:async-deprecate). Open to feedback, happy to answer any questions.
