### PR TITLE
Fixup test-helpers/index.

### DIFF
--- a/addon/test-helper/utils.js
+++ b/addon/test-helper/utils.js
@@ -1,7 +1,9 @@
 function callForEach(prop, func) {
-  for (var i=0, l=this[prop].length;i<l;i++) {
-    this[prop][i][func]();
-  }
+  return function() {
+    for (var i=0, l=this[prop].length;i<l;i++) {
+      this[prop][i][func]();
+    }
+  };
 }
 
 export function buildCompositeAssert(klasses){
@@ -16,10 +18,10 @@ export function buildCompositeAssert(klasses){
   };
 
   Composite.prototype = {
-    reset: callForEach('assertions', 'reset'),
-    inject: callForEach('assertions', 'reset'),
-    assert: callForEach('assertions', 'reset'),
-    restore: callForEach('assertions', 'restore')
+    reset: callForEach('asserts', 'reset'),
+    inject: callForEach('asserts', 'inject'),
+    assert: callForEach('asserts', 'assert'),
+    restore: callForEach('asserts', 'restore')
   };
 
   return Composite;

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -1,0 +1,59 @@
+import { buildCompositeAssert } from 'ember-dev/test-helper/utils';
+
+var resetCount, injectCount, assertCount, restoreCount;
+var Composite, instance, Ember;
+
+function generateAssertion() {
+  function A() {}
+  A.prototype = {
+    reset: function() { resetCount++; },
+    inject: function() { injectCount++; },
+    assert: function() { assertCount++; },
+    restore: function() { restoreCount++; }
+  };
+
+  return A;
+}
+
+module('buildCompositeAssert', {
+  setup: function() {
+    Ember = {};
+
+    resetCount = 0;
+    injectCount = 0;
+    assertCount = 0;
+    restoreCount = 0;
+
+    Composite = buildCompositeAssert([
+      generateAssertion(),
+      generateAssertion(),
+      generateAssertion()
+    ]);
+
+    instance = new Composite(Ember, false);
+  }
+});
+
+test('calls reset on all assertions added', function() {
+  instance.reset();
+
+  equal(resetCount, 3);
+});
+
+test('calls inject on all assertions added', function() {
+  instance.inject();
+
+  equal(injectCount, 3);
+});
+
+test('calls assert on all assertions added', function() {
+  instance.assert();
+
+  equal(assertCount, 3);
+});
+
+test('calls restore on all assertions added', function() {
+  instance.restore();
+
+  equal(restoreCount, 3);
+});


### PR DESCRIPTION
- Use `asserts` instead of `assertions` (that is what is used internally in the helpers).
- Make `callForEach` a function generator (so that `this.asserts`
  works).
