### PR TITLE
Add setup-qunit helper function.

### DIFF
--- a/addon/test-helper/setup-qunit.js
+++ b/addon/test-helper/setup-qunit.js
@@ -1,0 +1,37 @@
+/* globals QUnit */
+
+export default function setupQUnit(assertion, _qunitGlobal) {
+  var qunitGlobal = QUnit;
+
+  if (_qunitGlobal) {
+    qunitGlobal = _qunitGlobal;
+  }
+
+  var originalModule = qunitGlobal.module;
+
+  qunitGlobal.module = function(name, _originalOptions) {
+    var originalOptions = _originalOptions || {};
+
+    var options = {
+      setup: function() {
+        var originalCallback = originalOptions.setup || function() { };
+
+        assertion.reset();
+        assertion.inject();
+
+        originalCallback();
+      },
+
+      teardown: function() {
+        var originalCallback = originalOptions.teardown || function() { };
+
+        assertion.assert();
+        assertion.restore();
+
+        originalCallback();
+      }
+    };
+
+    return originalModule(name, options);
+  };
+}

--- a/tests/unit/setup-qunit-test.js
+++ b/tests/unit/setup-qunit-test.js
@@ -1,0 +1,128 @@
+import setupQUnit from 'ember-dev/test-helper/setup-qunit';
+
+var fakeQUnit, actualName, actualOptions, assertion;
+var resetCount, injectCount, assertCount, restoreCount;
+
+var modules;
+function generateFakeQUnit() {
+  return {
+    module: function(name, options) {
+      modules[name] = options;
+    }
+  };
+}
+
+
+function generateAssertion() {
+  return {
+    reset: function() { resetCount++; },
+    inject: function() { injectCount++; },
+    assert: function() { assertCount++; },
+    restore: function() { restoreCount++; }
+  };
+}
+
+function commonSetup() {
+  modules = {};
+
+  resetCount = 0;
+  injectCount = 0;
+  assertCount = 0;
+  restoreCount = 0;
+
+  assertion = generateAssertion();
+  fakeQUnit = generateFakeQUnit();
+  setupQUnit(assertion, fakeQUnit);
+}
+
+module('setupQUnit -- without options', {
+  setup: commonSetup
+});
+
+test('it does not blow up without options', function() {
+  fakeQUnit.module('something');
+
+  var module = modules['something'];
+
+  ok(module, 'module is found');
+  ok(typeof module.setup === 'function', 'setup function was added');
+  ok(typeof module.teardown === 'function', 'teardown function was added');
+});
+
+test('setup invokes reset + inject on assertion', function() {
+  fakeQUnit.module('something');
+
+  var module = modules['something'];
+
+  module.setup();
+  equal(resetCount, 1, 'called reset on assertion');
+  equal(injectCount, 1, 'called inject on assertion');
+});
+
+test('teardown invokes assert + restore on assertion', function() {
+  fakeQUnit.module('something');
+
+  var module = modules['something'];
+
+  module.teardown();
+  equal(assertCount, 1, 'called assert on assertion');
+  equal(restoreCount, 1, 'called restore on assertion');
+});
+
+module('setupQUnit -- with setup', {
+  setup: commonSetup
+});
+
+test('setup invokes reset + inject + custom setup', function() {
+  var setupCalled;
+
+  fakeQUnit.module('something', {
+    setup: function() { setupCalled = true; }
+  });
+
+  var module = modules['something'];
+
+  module.setup();
+
+  equal(resetCount, 1, 'called reset on assertion');
+  equal(injectCount, 1, 'called inject on assertion');
+  equal(setupCalled, true, 'called custom setup');
+});
+
+test('teardown invokes assert + restore on assertion', function() {
+  fakeQUnit.module('something');
+
+  var module = modules['something'];
+
+  module.teardown();
+  equal(assertCount, 1, 'called assert on assertion');
+  equal(restoreCount, 1, 'called restore on assertion');
+});
+
+module('setupQUnit -- with teardown', {
+  setup: commonSetup
+});
+
+test('setup invokes reset + inject on assertion', function() {
+  fakeQUnit.module('something');
+
+  var module = modules['something'];
+
+  module.setup();
+  equal(resetCount, 1, 'called reset on assertion');
+  equal(injectCount, 1, 'called inject on assertion');
+});
+
+test('teardown invokes assert + restore on assertion', function() {
+  var teardownCalled;
+  fakeQUnit.module('something', {
+    teardown: function() { teardownCalled = true; }
+  });
+
+  var module = modules['something'];
+
+  module.teardown();
+  equal(assertCount, 1, 'called assert on assertion');
+  equal(restoreCount, 1, 'called restore on assertion');
+  equal(teardownCalled, true, 'called custom teardown');
+});


### PR DESCRIPTION
Wraps `QUnit.module` to ensure assertion functions are called properly.

---

This is required to have the `expect` counts add up properly.
