### PR TITLE
Ensure prod build assertions are only made once.

### DIFF
--- a/addon/test-helper/deprecation.js
+++ b/addon/test-helper/deprecation.js
@@ -100,11 +100,11 @@ DeprecationAssert.prototype = {
   // without explicit asserts.
   //
   assert: function(){
-    var expecteds = this.expecteds,
+    var expecteds = this.expecteds || [],
         actuals   = this.actuals || [];
     var o, i;
 
-    if (!expecteds) {
+    if (expecteds.length === 0 && actuals.length === 0) {
       return;
     }
 

--- a/tests/unit/deprecation-test.js
+++ b/tests/unit/deprecation-test.js
@@ -60,6 +60,21 @@ test('expectDeprecation uses the provided callback', function(){
   });
 });
 
+test('expectDeprecation makes a single assertion regardless of deprecation in production builds', function(){
+  expect(2);
+
+  var Ember = { deprecate: function(){} };
+  assertion = new DeprecationAssert({Ember: Ember, runningProdBuild: true});
+
+  assertion.inject();
+
+  window.expectDeprecation(function() {
+    ok(true, 'callback was called in production');
+  });
+
+  assertion.assert();
+});
+
 test('expectDeprecation with a provided callback only asserts once', function(){
   expect(1);
 


### PR DESCRIPTION
When running `expectAssertion(callbackFN)` `this.expecteds` was an empty array (because the assertion was already done) so it passed the previous guard.

Now we just check to see if `this.expecteds` AND `this.actuals` are empty before short curcuiting.
