### PR TITLE
Properly `expectDeprecation` when `test` parameter is a function

### DIFF
--- a/addon/test-helper/deprecation.js
+++ b/addon/test-helper/deprecation.js
@@ -23,11 +23,12 @@ DeprecationAssert.prototype = {
     }
     var assertion = this;
     this.env.Ember.deprecate = function(msg, test) {
-      var pushDeprecation = typeof test === 'function' ? !test() : !test;
+      var resultOfTest = typeof test === 'function' ? test() : test;
+      var shouldDeprecate = !resultOfTest;
 
       assertion.actuals = assertion.actuals || [];
-      if (pushDeprecation) {
-        assertion.actuals.push([msg, test]);
+      if (shouldDeprecate) {
+        assertion.actuals.push([msg, resultOfTest]);
       }
     };
   },

--- a/tests/unit/deprecation-test.js
+++ b/tests/unit/deprecation-test.js
@@ -67,7 +67,7 @@ test('expectDeprecation fires when an expected deprecation does not pass for fun
   assertion.assert();
 });
 
-test('expectDeprecation fires when an expected deprecation does not pass for functions', function(){
+test('expectDeprecation fires when an expected deprecation does pass for functions', function(){
   expect(1);
 
   var Ember = { deprecate: function(){} };
@@ -77,7 +77,7 @@ test('expectDeprecation fires when an expected deprecation does not pass for fun
   window.expectDeprecation();
 
   QUnit.ok = function(isOk){
-    originalOk(!isOk);
+    originalOk(isOk);
   };
 
   Ember.deprecate('some dep', function() {


### PR DESCRIPTION
`Ember.deprecate` is called with `(message, test, options)`. When
`test` is falsy or a function that evaluates to falsy, the deprecation
is issued.

`expectDeprecation` was correctly evaluating the `test` param when it is
a function, but not pushing the correct result of that function into
`actuals`. This made using `expectDeprecate` fail for a deprecation that used
a test function.

Example:

```
// Ember code
function foo() {
  Ember.deprecate('message', function() { return false; });
}

// test code -- this test would erroneously fail because
// expectDeprecation pushes ['message', function() { return false; }]
// onto actuals instead of ['message', false]
expectDeprecation(function() {
  foo();
}, 'message');
```