### PR TITLE
Fixed issue with duplicate var statement causing transpiler issues

### DIFF
--- a/addon/test-helper/utils.js
+++ b/addon/test-helper/utils.js
@@ -27,7 +27,7 @@ export function buildCompositeAssert(klasses){
   return Composite;
 }
 
-var o_create = Object.create || (function(){
+export var o_create = Object.create || (function(){
   function F(){}
 
   return function(o) {
@@ -38,5 +38,3 @@ var o_create = Object.create || (function(){
     return new F();
   };
 }());
-
-export var o_create;


### PR DESCRIPTION
Compiling using [`broccoli-es6-module-transpiler`](https://github.com/mmun/broccoli-es6-module-transpiler`) v0.5.0 produces the following error:

```
expected exactly one declaration for export `o_create` at ember-dev/test-helper/utils.js:46:10, found 2
```