### PR TITLE
Added `Ember.warn` helpers

### DIFF
--- a/addon/test-helper/debug.js
+++ b/addon/test-helper/debug.js
@@ -1,0 +1,59 @@
+import MethodCallTracker from './method-call-tracker';
+
+class DebugAssert {
+  constructor(methodName, env) {
+    this.methodName = methodName;
+    this.env = env;
+  }
+
+  inject() {}
+
+  restore() {
+    this.reset();
+  }
+
+  reset() {
+    if (this.tracker) {
+      this.tracker.restoreMethod();
+    }
+
+    this.tracker = null;
+  }
+
+  assert() {
+    if (this.tracker) {
+      this.tracker.assert();
+    }
+  }
+
+  // Run an expectation callback within the context of a new tracker, optionally
+  // accepting a function to run, which asserts immediately
+  runExpectation(func, callback)  {
+    let originalTracker;
+
+    // When helpers are passed a callback, they get a new tracker context
+    if (func) {
+      originalTracker = this.tracker;
+      this.tracker = null;
+    }
+
+    if (!this.tracker) {
+      this.tracker = new MethodCallTracker(this.env, this.methodName);
+    }
+
+    // Yield to caller with tracker instance
+    callback(this.tracker);
+
+    // Once the given callback is invoked, the pending assertions should be
+    // flushed immediately
+    if (func) {
+      func();
+      this.assert();
+      this.reset();
+
+      this.tracker = originalTracker;
+    }
+  }
+}
+
+export default DebugAssert;

--- a/addon/test-helper/deprecation.js
+++ b/addon/test-helper/deprecation.js
@@ -1,18 +1,10 @@
-import MethodCallTracker from './method-call-tracker';
+import DebugAssert from './debug';
 import { callWithStub } from './utils';
 
-var DeprecationAssert = function(env) {
-  this.env = env;
-};
-
-DeprecationAssert.prototype = {
-  reset() {
-    if (this.tracker) {
-      this.tracker.restoreMethod();
-    }
-
-    this.tracker = null;
-  },
+class DeprecationAssert extends DebugAssert {
+  constructor(env) {
+    super('deprecate', env);
+  }
 
   inject() {
     // Expects no deprecation to happen within a function, or if no function is
@@ -73,58 +65,14 @@ DeprecationAssert.prototype = {
     window.expectNoDeprecation = expectNoDeprecation;
     window.expectDeprecation = expectDeprecation;
     window.ignoreDeprecation = ignoreDeprecation;
-  },
-
-  // Forces an assert the deprecations occurred, and resets the globals
-  // storing asserts for the next run.
-  //
-  // expectNoDeprecation(/Old/);
-  // setTimeout(function() {
-  //   Ember.deprecate("Old And Busted");
-  //   assertDeprecation();
-  // });
-  //
-  // assertDeprecation is called after each test run to catch any expectations
-  // without explicit asserts.
-  //
-  assert() {
-    if (this.tracker) {
-      this.tracker.assert();
-    }
-  },
+  }
 
   restore() {
-    this.reset();
+    super.restore();
     window.expectDeprecation = null;
     window.expectNoDeprecation = null;
     window.ignoreDeprecation = null;
-  },
-
-  runExpectation(func, callback)  {
-    let originalTracker;
-
-    // When helpers are passed a callback, they get a new tracker context
-    if (func) {
-      originalTracker = this.tracker;
-      this.tracker = null;
-    }
-
-    if (!this.tracker) {
-      this.tracker = new MethodCallTracker(this.env, 'deprecate');
-    }
-
-    callback(this.tracker);
-
-    // Once the given callback is invoked, the pending assertions should be
-    // flushed immediately
-    if (func) {
-      func();
-      this.assert();
-      this.reset();
-
-      this.tracker = originalTracker;
-    }
   }
-};
+}
 
 export default DeprecationAssert;

--- a/addon/test-helper/deprecation.js
+++ b/addon/test-helper/deprecation.js
@@ -34,18 +34,36 @@ DeprecationAssert.prototype = {
   },
 
   inject() {
-    // Expects no deprecation to happen from the time of calling until
-    // the end of the test.
+    // Expects no deprecation to happen within a function, or if no function is
+    // passed, from the time of calling until the end of the test.
+    //
+    // expectNoDeprecation(function() {
+    //   fancyNewThing();
+    // });
     //
     // expectNoDeprecation();
     // Ember.deprecate("Old And Busted");
     //
-    let expectNoDeprecation = () => {
+    let expectNoDeprecation = (func) => {
+      var originalExpecteds, originalActuals;
+
       if (this.expecteds != null && typeof this.expecteds === 'object') {
         throw new Error("expectNoDeprecation was called after expectDeprecation was called!");
       }
+
+      originalExpecteds = this.expecteds ? this.expecteds.slice() : this.expecteds;
+      originalActuals = this.actuals ? this.actuals.slice() : this.actuals;
+
       this.stubEmber();
       this.expecteds = NONE;
+
+      if (func && typeof func === 'function') {
+        func();
+        this.assert();
+
+        this.expecteds = originalExpecteds;
+        this.actuals = originalActuals;
+      }
     };
 
     // Expect a deprecation to happen within a function, or if no function

--- a/addon/test-helper/deprecation.js
+++ b/addon/test-helper/deprecation.js
@@ -37,7 +37,7 @@ DeprecationAssert.prototype = {
     // Expects no deprecation to happen from the time of calling until
     // the end of the test.
     //
-    // expectNoDeprecation(/* optionalStringOrRegex */);
+    // expectNoDeprecation();
     // Ember.deprecate("Old And Busted");
     //
     let expectNoDeprecation = () => {

--- a/addon/test-helper/index.js
+++ b/addon/test-helper/index.js
@@ -1,4 +1,5 @@
 import DeprecationAssert from "./deprecation";
+import WarningAssert from "./warning";
 import RemainingViewAssert from "./remaining-view";
 import RemainingTemplateAssert from "./remaining-template";
 import AssertionAssert from "./assertion";
@@ -8,6 +9,7 @@ import {buildCompositeAssert} from "./utils";
 
 var EmberDevTestHelperAssert = buildCompositeAssert([
   DeprecationAssert,
+  WarningAssert,
   RemainingViewAssert,
   RemainingTemplateAssert,
   AssertionAssert,

--- a/addon/test-helper/method-call-tracker.js
+++ b/addon/test-helper/method-call-tracker.js
@@ -1,0 +1,120 @@
+/* globals QUnit */
+
+import { checkTest } from './utils';
+
+var MethodCallTracker = function(env, methodName) {
+  this._env = env;
+  this._methodName = methodName;
+  this._isExpectingNoCalls = false;
+  this._expecteds = [];
+  this._actuals = [];
+};
+
+MethodCallTracker.prototype = {
+  stubMethod() {
+    if (this._originalMethod) {
+      // Method is already stubbed
+      return;
+    }
+
+    const env = this._env;
+    const methodName = this._methodName;
+
+    this._originalMethod = env.getDebugFunction(methodName);
+
+    env.setDebugFunction(methodName, (message, test) => {
+      const resultOfTest = checkTest(test);
+
+      this._actuals.push([ message, resultOfTest ]);
+    });
+  },
+
+  restoreMethod() {
+    if (this._originalMethod) {
+      this._env.setDebugFunction(this._methodName, this._originalMethod);
+    }
+  },
+
+  expectCall(message) {
+    this.stubMethod();
+    this._expecteds.push(message || /.*/);
+  },
+
+  expectNoCalls() {
+    this.stubMethod();
+    this._isExpectingNoCalls = true;
+  },
+
+  isExpectingNoCalls() {
+    return this._isExpectingNoCalls;
+  },
+
+  isExpectingCalls() {
+    return !this._isExpectingNoCalls && this._expecteds.length;
+  },
+
+  assert() {
+    const env = this._env;
+    const methodName = this._methodName;
+    const isExpectingNoCalls = this._isExpectingNoCalls;
+    const expecteds = this._expecteds;
+    const actuals = this._actuals;
+    let o, i;
+
+    if (!isExpectingNoCalls && expecteds.length === 0 && actuals.length === 0) {
+      return;
+    }
+
+    if (env.runningProdBuild) {
+      QUnit.ok(true, `calls to Ember.${methodName} disabled in production builds.`);
+      return;
+    }
+
+    if (isExpectingNoCalls) {
+      let actualMessages = [];
+      for (i = 0; i < actuals.length; i++) {
+        if (!actuals[i][1]) {
+          actualMessages.push(actuals[i][0]);
+        }
+      }
+      QUnit.ok(actualMessages.length === 0, `Expected no Ember.${methodName} calls, got ${actuals.length}: ${actualMessages.join(', ')}`);
+      return;
+    }
+
+    let expected, actual, match;
+
+    for (o = 0; o < expecteds.length; o++) {
+      expected = expecteds[o];
+      for (i = 0; i < actuals.length; i++) {
+        actual = actuals[i];
+        if (!actual[1]) {
+          if (expected instanceof RegExp) {
+            if (expected.test(actual[0])) {
+              match = actual;
+              break;
+            }
+          } else {
+            if (expected === actual[0]) {
+              match = actual;
+              break;
+            }
+          }
+        }
+      }
+
+      if (!actual) {
+        QUnit.ok(false, `Recieved no Ember.${methodName} calls at all, expecting: ${expected}`);
+      } else if (match && !match[1]) {
+        QUnit.ok(true, `Recieved failing Ember.${methodName} call with message: ${match[0]}`);
+      } else if (match && match[1]) {
+        QUnit.ok(false, `Expected failing Ember.${methodName} call, got succeeding with message: ${match[0]}`);
+      } else if (actual[1]) {
+        QUnit.ok(false, `Did not receive failing Ember.${methodName} call matching '${expected}', last was success with '${actual[0]}'`);
+      } else if (!actual[1]) {
+        QUnit.ok(false, `Did not receive failing Ember.${methodName} call matching '${expected}', last was failure with '${actual[0]}'`);
+      }
+    }
+  }
+};
+
+export default MethodCallTracker;

--- a/addon/test-helper/warning.js
+++ b/addon/test-helper/warning.js
@@ -1,0 +1,78 @@
+import DebugAssert from './debug';
+import { callWithStub } from './utils';
+
+class WarningAssert extends DebugAssert {
+  constructor(env) {
+    super('warn', env);
+  }
+
+  inject() {
+    // Expects no warning to happen within a function, or if no function is
+    // passed, from the time of calling until the end of the test.
+    //
+    // expectNoWarning(function() {
+    //   fancyNewThing();
+    // });
+    //
+    // expectNoWarning();
+    // Ember.warn("Oh snap, didn't expect that");
+    //
+    let expectNoWarning = (func) => {
+      if (typeof func !== 'function') {
+        func = null;
+      }
+
+      this.runExpectation(func, (tracker) => {
+        if (tracker.isExpectingCalls()) {
+          throw new Error("expectNoWarning was called after expectWarning was called!");
+        }
+
+        tracker.expectNoCalls();
+      });
+    };
+
+    // Expect a warning to happen within a function, or if no function is
+    // passed, from the time of calling until the end of the test. Can be called
+    // multiple times to assert warnings with different specific messages
+    // happened.
+    //
+    // expectWarning(function() {
+    //   Ember.warn("Times they are a-changin'");
+    // }, /* optionalStringOrRegex */);
+    //
+    // expectWarning(/* optionalStringOrRegex */);
+    // Ember.warn("Times definitely be changin'");
+    //
+    let expectWarning = (fn, message) => {
+      if (typeof fn !== 'function') {
+        message = fn;
+        fn = null;
+      }
+
+      this.runExpectation(fn, (tracker) => {
+        if (tracker.isExpectingNoCalls()) {
+          throw new Error("expectWarning was called after expectNoWarning was called!");
+        }
+
+        tracker.expectCall(message);
+      });
+    };
+
+    let ignoreWarning = (func) => {
+      callWithStub(this.env, 'warn', func);
+    };
+
+    window.expectNoWarning = expectNoWarning;
+    window.expectWarning = expectWarning;
+    window.ignoreWarning = ignoreWarning;
+  }
+
+  restore() {
+    super.restore();
+    window.expectWarning = null;
+    window.expectNoWarning = null;
+    window.ignoreWarning = null;
+  }
+}
+
+export default WarningAssert;

--- a/tests/unit/deprecation-test.js
+++ b/tests/unit/deprecation-test.js
@@ -24,6 +24,19 @@ module('DeprecationAssert', {
   }
 });
 
+test('Ember.deprecate is restored properly', function() {
+  expect(1);
+
+  assertion = new DeprecationAssert(env);
+
+  assertion.inject();
+  // Force the method to be stubbed
+  window.expectNoDeprecation();
+  assertion.restore();
+
+  equal(env.getDebugFunction('deprecate'), originalDeprecate);
+});
+
 test('expectDeprecation fires when an expected deprecation is not called', function(){
   expect(1);
 
@@ -282,6 +295,25 @@ test('expectNoDeprecation fires when an un-expected deprecation calls', function
   };
 
   Ember.deprecate('some dep');
+
+  assertion.assert();
+});
+
+test('expectNoDeprecation fires when a deprecation does not pass for functions', function(){
+  expect(1);
+
+  assertion = new DeprecationAssert(makeEnv());
+
+  assertion.inject();
+  window.expectNoDeprecation();
+
+  QUnit.ok = function(isOk){
+    originalOk(isOk);
+  };
+
+  Ember.deprecate('some dep', function() {
+    return true;
+  });
 
   assertion.assert();
 });

--- a/tests/unit/deprecation-test.js
+++ b/tests/unit/deprecation-test.js
@@ -316,6 +316,22 @@ test('expectNoDeprecation ignores a deprecation with an argument invalidating it
   assertion.assert();
 });
 
+test('expectNoDeprecation uses the provided callback', function(){
+  expect(1);
+
+  assertion = new DeprecationAssert(makeEnv());
+
+  assertion.inject();
+
+  QUnit.ok = function(isOk){
+    originalOk(!isOk);
+  };
+
+  window.expectNoDeprecation(function() {
+    Ember.deprecate('some dep');
+  });
+});
+
 test('ignoreDeprecation silences deprecations', function(){
   expect(1);
 

--- a/tests/unit/deprecation-test.js
+++ b/tests/unit/deprecation-test.js
@@ -39,6 +39,70 @@ test('expectDeprecation fires when an expected deprecation is not called', funct
   assertion.assert();
 });
 
+test('expectDeprecation asserts when string does not match exactly', function(){
+  expect(1);
+
+  assertion = new DeprecationAssert(makeEnv());
+
+  assertion.inject();
+
+  QUnit.ok = function(isOk){
+    originalOk(!isOk);
+  };
+
+  window.expectDeprecation('some dep');
+
+  Ember.deprecate('some dep with long desc');
+
+  assertion.assert();
+});
+
+test('expectDeprecation does not assert when string matches exactly', function(){
+  expect(1);
+
+  assertion = new DeprecationAssert(makeEnv());
+
+  assertion.inject();
+
+  window.expectDeprecation('some dep');
+
+  Ember.deprecate('some dep');
+
+  assertion.assert();
+});
+
+test('expectDeprecation asserts when regex does not match', function(){
+  expect(1);
+
+  assertion = new DeprecationAssert(makeEnv());
+
+  assertion.inject();
+
+  QUnit.ok = function(isOk){
+    originalOk(!isOk);
+  };
+
+  window.expectDeprecation(/some dep/);
+
+  Ember.deprecate('some different dep');
+
+  assertion.assert();
+});
+
+test('expectDeprecation does not assert when regex matches', function(){
+  expect(1);
+
+  assertion = new DeprecationAssert(makeEnv());
+
+  assertion.inject();
+
+  window.expectDeprecation(/some dep/);
+
+  Ember.deprecate('some dep with long desc');
+
+  assertion.assert();
+});
+
 test('expectDeprecation fires when an expected deprecation does not pass for boolean values', function(){
   expect(1);
 
@@ -105,6 +169,62 @@ test('expectDeprecation uses the provided callback', function(){
   window.expectDeprecation(function() {
     Ember.deprecate('some dep');
   });
+});
+
+test('expectDeprecation asserts when given a callback and string does not match exactly', function(){
+  expect(1);
+
+  assertion = new DeprecationAssert(makeEnv());
+
+  assertion.inject();
+
+  QUnit.ok = function(isOk){
+    originalOk(!isOk);
+  };
+
+  window.expectDeprecation(function() {
+    Ember.deprecate('some dep with long desc');
+  }, 'some dep');
+});
+
+test('expectDeprecation does not assert when given a callback and string matches exactly', function(){
+  expect(1);
+
+  assertion = new DeprecationAssert(makeEnv());
+
+  assertion.inject();
+
+  window.expectDeprecation(function() {
+    Ember.deprecate('some dep');
+  }, 'some dep');
+});
+
+test('expectDeprecation asserts when given a callback and regex does not match', function(){
+  expect(1);
+
+  assertion = new DeprecationAssert(makeEnv());
+
+  assertion.inject();
+
+  QUnit.ok = function(isOk){
+    originalOk(!isOk);
+  };
+
+  window.expectDeprecation(function() {
+    Ember.deprecate('some different dep');
+  }, /some dep/);
+});
+
+test('expectDeprecation does not assert when given a callback and regex matches', function(){
+  expect(1);
+
+  assertion = new DeprecationAssert(makeEnv());
+
+  assertion.inject();
+
+  window.expectDeprecation(function() {
+    Ember.deprecate('some dep with long desc');
+  }, /some dep/);
 });
 
 test('expectDeprecation makes a single assertion regardless of deprecation in production builds', function(){
@@ -234,13 +354,3 @@ test('using expectNoDeprecation and expectDeprecation together throws an error',
     equal(error.message, 'expectNoDeprecation was called after expectDeprecation was called!');
   }
 });
-
-/* Pending:
-test('expect no deprecation with regex matcher');
-test('expect no deprecation with string matcher');
-test('expect deprecation with regex matcher');
-test('expect deprecation with string matcher');
-test('expect deprecation with block form');
-test('expect deprecation with block form and string matcher');
-test('expect deprecation with block form and regex matcher');
-*/

--- a/tests/unit/warning-test.js
+++ b/tests/unit/warning-test.js
@@ -1,0 +1,405 @@
+import Ember from 'ember';
+import WarningAssert from 'ember-dev/test-helper/warning';
+import makeEnv from '../helpers/make-env';
+
+let originalOk;
+let originalWarn;
+let assertion;
+
+let env = makeEnv();
+
+module('WarningAssert', {
+  beforeEach() {
+    originalOk = QUnit.ok;
+    originalWarn = env.getDebugFunction('warn');
+  },
+  afterEach() {
+    QUnit.ok = originalOk;
+    env.setDebugFunction('warn', originalWarn);
+
+    if (assertion) {
+      assertion.restore();
+      assertion = null;
+    }
+  }
+});
+
+test('Ember.warn is restored properly', function() {
+  expect(1);
+
+  assertion = new WarningAssert(env);
+
+  assertion.inject();
+  // Force the method to be stubbed
+  window.expectNoWarning();
+  assertion.restore();
+
+  equal(env.getDebugFunction('warn'), originalWarn);
+});
+
+test('expectWarning fires when an expected warning is not logged', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+  window.expectWarning();
+
+  QUnit.ok = function(isOk){
+    originalOk(!isOk);
+  };
+
+  assertion.assert();
+});
+
+test('expectWarning asserts when string does not match exactly', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  QUnit.ok = function(isOk) {
+    originalOk(!isOk);
+  };
+
+  window.expectWarning('oh');
+
+  Ember.warn('oh noes');
+
+  assertion.assert();
+});
+
+test('expectWarning does not assert when string matches exactly', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  window.expectWarning('wat');
+
+  Ember.warn('wat');
+
+  assertion.assert();
+});
+
+test('expectWarning asserts when regex does not match', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  QUnit.ok = function(isOk) {
+    originalOk(!isOk);
+  };
+
+  window.expectWarning(/woop woop/);
+
+  Ember.warn('whoops whoops');
+
+  assertion.assert();
+});
+
+test('expectWarning does not assert when regex matches', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  window.expectWarning(/woop! woop!/);
+
+  Ember.warn('woop! woop! woop!');
+
+  assertion.assert();
+});
+
+test('expectWarning fires when an expected warning does not pass for boolean values', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+  window.expectWarning();
+
+  QUnit.ok = function(isOk){
+    originalOk(!isOk);
+  };
+
+  Ember.warn('nooooooo', true);
+
+  assertion.assert();
+});
+
+test('expectWarning fires when an expected warning does not pass for functions', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+  window.expectWarning();
+
+  QUnit.ok = function(isOk){
+    originalOk(!isOk);
+  };
+
+  Ember.warn('aaaahhhhhh', function() {
+    return true;
+  });
+
+  assertion.assert();
+});
+
+test('expectWarning fires when an expected warning does pass for functions', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+  window.expectWarning();
+
+  QUnit.ok = function(isOk) {
+    originalOk(isOk);
+  };
+
+  Ember.warn('omgomgomg', function() {
+    return false;
+  });
+
+  assertion.assert();
+});
+
+
+test('expectWarning uses the provided callback', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  window.expectWarning(function() {
+    Ember.warn('right in the ear!');
+  });
+});
+
+test('expectWarning asserts when given a callback and string does not match exactly', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  QUnit.ok = function(isOk) {
+    originalOk(!isOk);
+  };
+
+  window.expectWarning(function() {
+    Ember.warn('ugh');
+  }, 'argh');
+});
+
+test('expectWarning does not assert when given a callback and string matches exactly', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  window.expectWarning(function() {
+    Ember.warn('ugh');
+  }, 'ugh');
+});
+
+test('expectWarning asserts when given a callback and regex does not match', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  QUnit.ok = function(isOk) {
+    originalOk(!isOk);
+  };
+
+  window.expectWarning(function() {
+    Ember.warn('weeeoooweeeooo');
+  }, /weeeeeee/);
+});
+
+test('expectWarning does not assert when given a callback and regex matches', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  window.expectWarning(function() {
+    Ember.warn('weeeoooweeeooo');
+  }, /weeeooo/);
+});
+
+test('expectWarning makes a single assertion regardless of warning in production builds', function() {
+  expect(2);
+
+  assertion = new WarningAssert(makeEnv({ runningProdBuild: true }));
+
+  assertion.inject();
+
+  window.expectWarning(function() {
+    ok(true, 'snap, callback was called in production');
+  });
+
+  assertion.assert();
+});
+
+test('expectWarning with a provided callback only asserts once', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  window.expectWarning(function() {
+    Ember.warn('now you done it');
+  }, 'now you done it');
+
+  assertion.assert();
+});
+
+test('expectWarning with callback in production does not assert twice', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv({ runningProdBuild: true }));
+
+  assertion.inject();
+
+  window.expectWarning(function() {
+    Ember.warn('*sigh*');
+  });
+
+  assertion.assert();
+});
+
+test('expectNoWarning fires when an un-expected warning is logged', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+  window.expectNoWarning();
+
+  QUnit.ok = function(isOk){
+    originalOk(!isOk);
+  };
+
+  Ember.warn('wtf');
+
+  assertion.assert();
+});
+
+test('expectNoWarning does not assert when a warning does not pass for functions', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+  window.expectNoWarning();
+
+  QUnit.ok = function(isOk){
+    originalOk(isOk);
+  };
+
+  Ember.warn('oof', function() {
+    return true;
+  });
+
+  assertion.assert();
+});
+
+test('expectNoWarning makes an assertion in production mode', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv({ runningProdBuild: true }));
+
+  assertion.reset();
+  assertion.inject();
+
+  window.expectNoWarning();
+
+  assertion.assert();
+});
+
+test('expectNoWarning ignores a warning with an argument invalidating it', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+  window.expectNoWarning();
+
+  QUnit.ok = function(isOk) {
+    // this assertion should not fire
+    originalOk(!isOk);
+  };
+
+  Ember.warn('fuuuuuuuu', false);
+
+  assertion.assert();
+});
+
+test('expectNoWarning uses the provided callback', function() {
+  expect(1);
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  QUnit.ok = function(isOk){
+    originalOk(!isOk);
+  };
+
+  window.expectNoWarning(function() {
+    Ember.warn('No humor in tests pls');
+  });
+});
+
+test('ignoreWarning silences warnings', function() {
+  expect(1);
+
+  let env = makeEnv();
+  env.setDebugFunction('warn', function() {
+    originalOk(false, 'oh noes, should not call warn');
+  });
+
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+  window.ignoreWarning(function() {
+    ok(true, 'warn callback is run');
+    Ember.warn('srsly?');
+  });
+});
+
+test('using expectNoWarning and expectWarning together throws an error', function() {
+  assertion = new WarningAssert(makeEnv());
+
+  assertion.inject();
+
+  try {
+    window.expectNoWarning();
+    window.expectWarning();
+  } catch(error) {
+    equal(error.message, 'expectWarning was called after expectNoWarning was called!');
+  }
+
+  assertion.reset();
+
+  try {
+    window.expectWarning();
+    window.expectNoWarning();
+  } catch(error) {
+    equal(error.message, 'expectNoWarning was called after expectWarning was called!');
+  }
+});


### PR DESCRIPTION
Fixes #157

This PR adds the `expectWarning`, `expectNoWarning`, and `ignoreWarning` helpers whose behavior is identical to the similarly named deprecation helpers.

Along the way I implemented pending deprecation helper tests, added the ability to pass a callback to `expectNoDeprecation`, and refactored method call tracking into a util.